### PR TITLE
Do not specify hostportslist when update strategy is rolling update

### DIFF
--- a/test/ix-chart/2010.0.2/values.yaml
+++ b/test/ix-chart/2010.0.2/values.yaml
@@ -20,7 +20,6 @@ containerEnvironmentVariables: []
 # Network related configuration
 externalInterfaces: []
 portForwardingList: []
-hostPortsList: []
 hostNetwork: false
 dnsPolicy: Default
 dnsConfig:


### PR DESCRIPTION
We should not specify a default value for host ports list as the attribute is not allowed when update strategy is rolling update which is the default.

Closes truenas/charts#6