### PR TITLE
Use nc instead of nslookup while waiting for postgres to come up

### DIFF
--- a/test/nextcloud/1.0.0/templates/deployment.yaml
+++ b/test/nextcloud/1.0.0/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
       initContainers:
         - name: init-postgresdb
           image: busybox:latest
-          command: ['sh', '-c', "until nslookup {{ template "nextcloud.fullname" . }}-postgres; do echo waiting for postgres; sleep 2; done"]
+          command: ['sh', '-c', "until nc -w 5 -vz {{ template "nextcloud.fullname" . }}-postgres 5432; do echo waiting for postgres; sleep 2; done"]
           imagePullPolicy: {{ .Values.image.pullPolicy }}
       containers:
       - name: {{ .Chart.Name }}


### PR DESCRIPTION
Using nslookup, the wait time for nextcloud pod to come up can be up to 1-5 minutes. This is reduced with nc to 5-10 seconds.