### PR TITLE
Remove requirements.yaml, due to Helm 3 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ charts/ix-chart/<chart version>/
   Chart.yaml               # Required Helm chart information file
   questions.yaml           # TrueNAS SCALE Specific: File containing questions for TrueNAS SCALE UI
   README.md                # Optional: Helm Readme file (will be rendered in TrueNAS SCALE UI as well)
-  requirements.yaml        # Optional YAML file listing dependencies for the chart
   templates/               # A directory of templates that, when combined with values.yml will generate K8s YAML
   values.yaml              # The default configuration values for this chart
 ```


### PR DESCRIPTION
Helm 3 merges requirements.yaml into Chart.yaml.
I tested this config with the CI and it works fine, it seems only fitting to remove requirements.yaml from the documentation. as it's depricated, every new chart uploaded to the repo should have it copy-pasted into the Chart.yaml (the syntax is still the same)