### PR TITLE
Fix wrong enum example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,12 @@ questions:
             type: string
             default: "IfNotPresent"
             enum:
-              - "IfNotPresent"
-              - "Always"
-              - "Never"
+              - value: "IfNotPresent"
+                description: "Only pull image if not present on host"
+              - value: "Always"
+                description: "Always pull image even if present on host"
+              - value: "Never"
+                description: "Never pull image even if it's not present on host"
 ```
 
 The above will prompt the user with 2 text fields and a dropdown in the UI getting details for image configuration in a helm chart.


### PR DESCRIPTION
This fixes a small example mistake in the readme for the enum