### PR TITLE
Use blue-text logo for nextcloud

### DIFF
--- a/charts/nextcloud/item.yaml
+++ b/charts/nextcloud/item.yaml
@@ -1,3 +1,3 @@
 categories:
   - productivity
-icon_url: https://cdn.rawgit.com/docker-library/docs/defa5ffc7123177acd60ddef6e16bddf694cc35f/nextcloud/logo.svg
+icon_url: https://upload.wikimedia.org/wikipedia/commons/thumb/6/60/Nextcloud_Logo.svg/1280px-Nextcloud_Logo.svg.png


### PR DESCRIPTION
black-on-black or gray-on-gray isn't acceptable.