### PR TITLE
Remove MD formating from app-readme.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ After that create `app-readme.md` file.
 ```
 $ cat charts/ix-chart/<chart version>/app-readme.md
 
-# iX-Chart
-
 iX-chart is a chart designed to let user deploy a docker image in a TrueNAS SCALE kubernetes cluster.
 It provides a mechanism to specify workload type, add external host interfaces in the pods, configure volumes and allocate host resources to the workload.
 ```


### PR DESCRIPTION
app-readme.md is actually just a TXT file, it gets rendered plaintext.
Hence one shouldn't use md header formatting on app-readme.md