### PR TITLE
[README] Fix broken [developer reference]

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ charts/ix-chart/<chart version>/
   templates/               # A directory of templates that, when combined with values.yml will generate K8s YAML
   values.yaml              # The default configuration values for this chart
 ```
-*See the upstream Helm chart [developer reference](https://helm.sh/docs/topics/chart_template_guide/) for a complete walk through of developing charts.*
+*See the upstream Helm chart [developer reference](https://helm.sh/docs/chart_template_guide/) for a complete walk through of developing charts.*
 
 To convert an upstream chart to take advantage of TrueNAS SCALE enhanced UX, first create an `item.yaml` file.
 This file among other catalog item information provides a list of categories that this chart fits into. This helps users navigate and filtering when browsing the catalog UI.


### PR DESCRIPTION
The link to the upstream Helm Chart Developer Reference is broken (404), this is the right link.