### PR TITLE
Increase definitions/certificate min stable version

### DIFF
--- a/features_capability.json
+++ b/features_capability.json
@@ -24,11 +24,11 @@
     "nightlies": {"min":  "20.12-MASTER"}
   },
   "definitions/certificate": {
-    "stable": {"min": "21.02-ALPHA"},
+    "stable": {"min": "21.04-ALPHA"},
     "nightlies": {"min": "21.02-MASTER"}
   },
   "definitions/certificateAuthority": {
-    "stable": {"min": "21.02-ALPHA"},
+    "stable": {"min": "21.04-ALPHA"},
     "nightlies": {"min": "21.02-MASTER"}
   }
 }


### PR DESCRIPTION
After testing on 21.02-ALPHA it seems like 21.02-ALPHA doesn't actually support the definitions/certificate and definitions/certificateAuthority very well (if at all).

Setting the stable to 21.04-ALPHA seems okey, while it isn't officially a planned release, it can always be adapted to the actual release date in the future.