### PR TITLE
Update chia versioning update strategy

### DIFF
--- a/charts/chia/upgrade_strategy
+++ b/charts/chia/upgrade_strategy
@@ -7,13 +7,14 @@ from catalog_update.upgrade_strategy import semantic_versioning
 
 def newer_mapping(image_tags):
     key = list(image_tags.keys())[0]
+    tags = {t.strip('v').replace('_', '.'): t for t in image_tags[key]}
     version = semantic_versioning(image_tags[key])
     if not version:
         return {}
 
     return {
-        'tags': {key: version},
-        'app_version': version,
+        'tags': {key: tags[version]},
+        'app_version': tags[version],
     }
 
 

--- a/test/chia/upgrade_strategy
+++ b/test/chia/upgrade_strategy
@@ -7,13 +7,14 @@ from catalog_update.upgrade_strategy import semantic_versioning
 
 def newer_mapping(image_tags):
     key = list(image_tags.keys())[0]
+    tags = {t.strip('v').replace('_', '.'): t for t in image_tags[key]}
     version = semantic_versioning(image_tags[key])
     if not version:
         return {}
 
     return {
-        'tags': {key: version},
-        'app_version': version,
+        'tags': {key: tags[version]},
+        'app_version': tags[version],
     }
 
 


### PR DESCRIPTION
This commit adds changes to update how we determine if we have an updated tag available for chia - recently we have shifted the versioning scheme on our docker image of chia and this change is to account for that so we can have automated updates.