### PR TITLE
NAS-112140 / 21.10 / Update nextcloud upgrade strategy

### DIFF
--- a/charts/nextcloud/upgrade_strategy
+++ b/charts/nextcloud/upgrade_strategy
@@ -7,7 +7,8 @@ from catalog_update.upgrade_strategy import semantic_versioning
 
 def newer_mapping(image_tags):
     key = list(image_tags.keys())[0]
-    version = semantic_versioning(image_tags[key])
+    # 21.1 is greater then 21.1.0 so we reverse sort bfeore doing semantic versioning
+    version = semantic_versioning(sorted(image_tags[key], reverse=True))
     if not version:
         return {}
 

--- a/test/nextcloud/upgrade_strategy
+++ b/test/nextcloud/upgrade_strategy
@@ -7,7 +7,8 @@ from catalog_update.upgrade_strategy import semantic_versioning
 
 def newer_mapping(image_tags):
     key = list(image_tags.keys())[0]
-    version = semantic_versioning(image_tags[key])
+    # 21.1 is greater then 21.1.0 so we reverse sort bfeore doing semantic versioning
+    version = semantic_versioning(sorted(image_tags[key], reverse=True))
     if not version:
         return {}
 


### PR DESCRIPTION
For nextcloud tags, 21.1 is greater then 21.1.0 so we reverse sort the tags list before doing semantic versioning as in semantic versioning both tags are equal and when we reverse sort it, 21.1 is prioritised over 21.1.0.