### PR TITLE
NAS-113798 / 22.02 / Fix machinaris configs update + Add additional env variables (base for workers setup) 

### DIFF
--- a/test/machinaris/1.1.0/ix_values.yaml
+++ b/test/machinaris/1.1.0/ix_values.yaml
@@ -4,6 +4,8 @@ image:
   tag: v0.6.7
 updateStrategy: Recreate
 
+apiPort: 8927
+farmerPort: 8447
 ports:
   - name: chia-network
     protocol: TCP
@@ -16,7 +18,8 @@ ports:
     protocol: TCP
     containerPort: 8927
     hostPort: 8927
-  - protocol: TCP
+  - name: farming
+    protocol: TCP
     containerPort: 8447
     hostPort: 8447
 
@@ -35,6 +38,7 @@ coins:
 
 cactus:
   apiPort: 8936
+  farmerPort: 11447
   ports:
     - name: api
       protocol: TCP
@@ -51,6 +55,7 @@ cactus:
 
 chives:
   apiPort: 8931
+  farmerPort: 9647
   ports:
     - name: api
       protocol: TCP
@@ -64,6 +69,7 @@ chives:
 
 cryptodoge:
   apiPort: 8937
+  farmerPort: 16895
   ports:
     - name: api
       protocol: TCP
@@ -77,6 +83,7 @@ cryptodoge:
 
 flax:
   apiPort: 8928
+  farmerPort: 6885
   ports:
     - name: api
       protocol: TCP
@@ -90,6 +97,7 @@ flax:
 
 flora:
   apiPort: 8932
+  farmerPort: 18647
   ports:
     - name: api
       protocol: TCP
@@ -103,6 +111,7 @@ flora:
 
 hddcoin:
   apiPort: 8930
+  farmerPort: 28447
   ports:
     - name: api
       protocol: TCP
@@ -116,6 +125,7 @@ hddcoin:
 
 maize:
   apiPort: 8933
+  farmerPort: 8647
   ports:
     - name: api
       protocol: TCP
@@ -129,6 +139,7 @@ maize:
 
 nchain:
   apiPort: 8929
+  farmerPort: 38447
   ports:
     - name: api
       protocol: TCP
@@ -142,6 +153,7 @@ nchain:
 
 staicoin:
   apiPort: 8934
+  farmerPort: 1692
   ports:
     - name: api
       protocol: TCP
@@ -155,6 +167,7 @@ staicoin:
 
 stor:
   apiPort: 8935
+  farmerPort: 8337
   ports:
     - name: api
       protocol: TCP
@@ -168,6 +181,7 @@ stor:
 
 btcgreen:
   apiPort: 8938
+  farmerPort: 18655
   ports:
     - name: api
       protocol: TCP

--- a/test/machinaris/1.1.0/questions.yaml
+++ b/test/machinaris/1.1.0/questions.yaml
@@ -249,6 +249,7 @@ questions:
           label: "Configure Cactus"
           schema:
             type: dict
+            additional_attrs: true
             attrs:
               - variable: volumeMounts
                 label: "Storage Configurations"
@@ -374,6 +375,7 @@ questions:
           label: "Configure Chives"
           schema:
             type: dict
+            additional_attrs: true
             attrs:
               - variable: volumeMounts
                 label: "Storage Configurations"
@@ -499,6 +501,7 @@ questions:
           label: "Configure Cryptodoge"
           schema:
             type: dict
+            additional_attrs: true
             attrs:
               - variable: volumeMounts
                 label: "Storage Configurations"
@@ -624,6 +627,7 @@ questions:
           label: "Configure Flax"
           schema:
             type: dict
+            additional_attrs: true
             attrs:
               - variable: volumeMounts
                 label: "Storage Configurations"
@@ -749,6 +753,7 @@ questions:
           label: "Configure Flora"
           schema:
             type: dict
+            additional_attrs: true
             attrs:
               - variable: volumeMounts
                 label: "Storage Configurations"
@@ -874,6 +879,7 @@ questions:
           label: "Configure HDDCoin"
           schema:
             type: dict
+            additional_attrs: true
             attrs:
               - variable: volumeMounts
                 label: "Storage Configurations"
@@ -999,6 +1005,7 @@ questions:
           label: "Configure Maize"
           schema:
             type: dict
+            additional_attrs: true
             attrs:
               - variable: volumeMounts
                 label: "Storage Configurations"
@@ -1124,6 +1131,7 @@ questions:
           label: "Configure N-Chain"
           schema:
             type: dict
+            additional_attrs: true
             attrs:
               - variable: volumeMounts
                 label: "Storage Configurations"
@@ -1249,6 +1257,7 @@ questions:
           label: "Configure Staicoin"
           schema:
             type: dict
+            additional_attrs: true
             attrs:
               - variable: volumeMounts
                 label: "Storage Configurations"
@@ -1374,7 +1383,7 @@ questions:
           label: "Configure Stor"
           schema:
             type: dict
-            show_if: [["storEnabled", "=", true]]
+            additional_attrs: true
             attrs:
               - variable: volumeMounts
                 label: "Storage Configurations"
@@ -1500,7 +1509,7 @@ questions:
           label: "Configure BTCGreen"
           schema:
             type: dict
-            show_if: [["btcgreenEnabled", "=", true]]
+            additional_attrs: true
             attrs:
               - variable: volumeMounts
                 label: "Storage Configurations"

--- a/test/machinaris/1.1.0/templates/coins-deployment.yaml
+++ b/test/machinaris/1.1.0/templates/coins-deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - name: extrappvolume-{{ $index }}
               mountPath: {{ $hostPathConfiguration.mountPath }}
           {{ end }}
-          {{ include "allEnvironmentVariables" (dict "defaultEnv" (dict "TZ" $ref.Values.timezone "worker_address" $ref.Values.nodeIP "controller_host" $ref.Values.nodeIP "worker_api_port" $coin.apiPort "blockchains" $coinName "plots_dir" $ref.Values.appVolumeMounts.plots.mountPath "mode" "fullnode") "environmentVariables" $coin.environmentVariables) | nindent 10 }}
+          {{ include "allEnvironmentVariables" (dict "defaultEnv" (dict "TZ" $ref.Values.timezone "worker_address" $ref.Values.nodeIP "worker_api_port" $coin.apiPort "controller_host" $ref.Values.nodeIP "controller_api_port" $coin.apiPort "farmer_address" $ref.Values.nodeIP "farmer_port" $coin.farmerPort "blockchains" $coinName "plots_dir" $ref.Values.appVolumeMounts.plots.mountPath "mode" "fullnode") "environmentVariables" $coin.environmentVariables) | nindent 10 }}
       volumes: {{ include "common.storage.configureAppVolumes" (dict "appVolumeMounts" $coin.volumeMounts "ixVolumes" $ref.Values.ixVolumes) | nindent 8 }}
       {{ range $index, $hostPathConfiguration := $ref.Values.extraAppVolumeMounts }}
         - name: extrappvolume-{{ $coinName }}-{{ $index }}

--- a/test/machinaris/1.1.0/templates/coins-deployment.yaml
+++ b/test/machinaris/1.1.0/templates/coins-deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - name: extrappvolume-{{ $index }}
               mountPath: {{ $hostPathConfiguration.mountPath }}
           {{ end }}
-          {{ include "allEnvironmentVariables" (dict "defaultEnv" (dict "TZ" $ref.Values.timezone "worker_address" $ref.Values.nodeIP "worker_api_port" $coin.apiPort "controller_host" $ref.Values.nodeIP "controller_api_port" $coin.apiPort "farmer_address" $ref.Values.nodeIP "farmer_port" $coin.farmerPort "blockchains" $coinName "plots_dir" $ref.Values.appVolumeMounts.plots.mountPath "mode" "fullnode") "environmentVariables" $coin.environmentVariables) | nindent 10 }}
+          {{ include "allEnvironmentVariables" (dict "defaultEnv" (dict "TZ" $ref.Values.timezone "worker_address" $ref.Values.nodeIP "worker_api_port" $coin.apiPort "controller_api_port" $coin.apiPort "farmer_port" $coin.farmerPort "blockchains" $coinName "plots_dir" $ref.Values.appVolumeMounts.plots.mountPath "mode" "fullnode") "environmentVariables" $coin.environmentVariables) | nindent 10 }}
       volumes: {{ include "common.storage.configureAppVolumes" (dict "appVolumeMounts" $coin.volumeMounts "ixVolumes" $ref.Values.ixVolumes) | nindent 8 }}
       {{ range $index, $hostPathConfiguration := $ref.Values.extraAppVolumeMounts }}
         - name: extrappvolume-{{ $coinName }}-{{ $index }}

--- a/test/machinaris/1.1.0/templates/deployment.yaml
+++ b/test/machinaris/1.1.0/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
               mountPath: {{ $hostPathConfiguration.mountPath }}
           {{ end }}
           {{ include "common.containers.configurePorts" .Values | nindent 10 }}
-          {{ include "allEnvironmentVariables" (dict "defaultEnv" (dict "TZ" .Values.timezone "worker_address" .Values.nodeIP "blockchains" "chia" "plots_dir" .Values.appVolumeMounts.plots.mountPath "mode" "fullnode") "environmentVariables" .Values.environmentVariables) | nindent 10 }}
+          {{ include "allEnvironmentVariables" (dict "defaultEnv" (dict "TZ" .Values.timezone "worker_address" .Values.nodeIP "worker_api_port" .Values.apiPort "controller_host" .Values.nodeIP "controller_api_port" .Values.apiPort "farmer_address" .Values.nodeIP "farmer_port" .Values.farmerPort "blockchains" "chia" "plots_dir" .Values.appVolumeMounts.plots.mountPath "mode" "fullnode") "environmentVariables" .Values.environmentVariables) | nindent 10 }}
       volumes: {{ include "common.storage.configureAppVolumes" .Values | nindent 8 }}
       {{ range $index, $hostPathConfiguration := .Values.extraAppVolumeMounts }}
         - name: extrappvolume-{{ $index }}

--- a/test/machinaris/1.1.0/templates/deployment.yaml
+++ b/test/machinaris/1.1.0/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
               mountPath: {{ $hostPathConfiguration.mountPath }}
           {{ end }}
           {{ include "common.containers.configurePorts" .Values | nindent 10 }}
-          {{ include "allEnvironmentVariables" (dict "defaultEnv" (dict "TZ" .Values.timezone "worker_address" .Values.nodeIP "worker_api_port" .Values.apiPort "controller_host" .Values.nodeIP "controller_api_port" .Values.apiPort "farmer_address" .Values.nodeIP "farmer_port" .Values.farmerPort "blockchains" "chia" "plots_dir" .Values.appVolumeMounts.plots.mountPath "mode" "fullnode") "environmentVariables" .Values.environmentVariables) | nindent 10 }}
+          {{ include "allEnvironmentVariables" (dict "defaultEnv" (dict "TZ" .Values.timezone "worker_address" .Values.nodeIP "worker_api_port" .Values.apiPort "controller_api_port" .Values.apiPort "farmer_port" .Values.farmerPort "blockchains" "chia" "plots_dir" .Values.appVolumeMounts.plots.mountPath "mode" "fullnode") "environmentVariables" .Values.environmentVariables) | nindent 10 }}
       volumes: {{ include "common.storage.configureAppVolumes" .Values | nindent 8 }}
       {{ range $index, $hostPathConfiguration := .Values.extraAppVolumeMounts }}
         - name: extrappvolume-{{ $index }}

--- a/test/machinaris/1.1.0/test_values.yaml
+++ b/test/machinaris/1.1.0/test_values.yaml
@@ -6,6 +6,8 @@ image:
 machinaris_ui_port: 31003
 machinarisApiPort: 8927
 
+apiPort: 8927
+farmerPort: 8447
 ports:
   - name: chia-network
     protocol: TCP
@@ -47,6 +49,7 @@ coins:
 cactusEnabled: true
 cactus:
   apiPort: 8936
+  farmerPort: 11447
   ports:
     - name: api
       protocol: TCP


### PR DESCRIPTION
Fix machinaris configs update + Add additional env variables (base for workers setup):

```python
Error: [EINVAL] chives.apiPort: Field was not expected [EINVAL] chives.ports: Field was not expected
Error: [EINVAL] cactus.apiPort: Field was not expected [EINVAL] cactus.ports: Field was not expected
...
```