### PR TITLE
NAS-117012 / 22.12 / Filter out non-stable releases for emby

### DIFF
--- a/test/emby/upgrade_strategy
+++ b/test/emby/upgrade_strategy
@@ -1,13 +1,20 @@
 #!/usr/bin/python3
 import json
+import re
 import sys
 
 from catalog_update.upgrade_strategy import semantic_versioning
 
 
+RE_STABLE_VERSION = re.compile(r'\d+.\d+.\d+.\d+')
+
+
 def newer_mapping(image_tags):
     key = list(image_tags.keys())[0]
-    version = semantic_versioning(sorted(image_tags[key], reverse=True))
+    version = semantic_versioning(sorted(
+        [tag for tag in image_tags[key] if RE_STABLE_VERSION.fullmatch(tag) and tag.split('.')[2] != '0'],
+        reverse=True
+    ))
     if not version:
         return {}
 


### PR DESCRIPTION
## Problem

It was pointed out by a user that the when the third digit in emby releases is a zero, it's not a stable release and hence we should avoid using it.

Reference: https://github.com/truenas/charts/issues/555