### PR TITLE
Fix qbittorrent upgrade strategy

### DIFF
--- a/test/qbittorent/upgrade_strategy
+++ b/test/qbittorent/upgrade_strategy
@@ -1,13 +1,17 @@
 #!/usr/bin/python3
 import json
+import re
 import sys
 
 from catalog_update.upgrade_strategy import semantic_versioning
 
 
+RE_STABLE_VERSION = re.compile(r'[0-9]\.[0-9]\.[0-9]')
+
+
 def newer_mapping(image_tags):
     key = list(image_tags.keys())[0]
-    tags = {t: t for t in image_tags[key]}
+    tags = {t: t for t in image_tags[key] if RE_STABLE_VERSION.fullmatch(t)}
     version = semantic_versioning(list(tags))
     if not version:
         return {}


### PR DESCRIPTION
## Problem

`linuxserver/qbittorrent` image has diverse tag names, however stable versions use a specific pattern. We were doing a semantic search on all of the tags which resulted in invalid tags being used and `qbittorrent` failing helm test.

## Solution

Make sure valid tags are used when sorting them based on semantic versioning.