### PR TITLE
[home-assistant] dnsPolicy and hostNetwork

### DIFF
--- a/charts/home-assistant/1.0.29/templates/deployment.yaml
+++ b/charts/home-assistant/1.0.29/templates/deployment.yaml
@@ -30,7 +30,10 @@ spec:
         {{- include "common.labels.selectorLabels" . | nindent 8 }}
       annotations: {{ include "common.annotations" . | nindent 8 }}
     spec:
+    {{- if .Values.hostNetwork }}
       hostNetwork: {{ .Values.hostNetwork }}
+      dnsPolicy: ClusterFirstWithHostNet
+    {{- end }}
       initContainers:
         - name: init-postgresdb
           image: {{ template "postgres.imageName" . }}


### PR DESCRIPTION
When `hostNetwork` is set to true, `dnsPolicy` should be set to `ClusterFirstWithHostNet` explicitly.