### PR TITLE
Add git workflows for upgrade strategy / info linting

### DIFF
--- a/.github/workflows/json_format_validation.yaml
+++ b/.github/workflows/json_format_validation.yaml
@@ -1,0 +1,15 @@
+name: json_format
+
+on: [push]
+
+jobs:
+  validation:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Validate json format
+      run: |
+        find -name upgrade_info.json -exec sh -c "cat {} | jq && exit 0 || echo $? >> .exit_status" \;
+        test -f jq_exit_status && rm .exit_status && exit 1; exit 0;

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,27 @@
+name: flake8
+
+on: [push]
+
+jobs:
+  lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8
+    - name: Setup flake8 config
+      run: |
+        echo '[flake8]' > setup.cfg
+        echo 'max-line-length = 120' >> setup.cfg
+    - name: Analysing the code with flake8
+      run: |
+        find -name upgrade_strategy -exec sh -c "flake8  {} && exit 0 || echo $? > .exit_status" \;
+        test -f .exit_status && rm .exit_status && exit 1; exit 0;


### PR DESCRIPTION
## Context

`upgrade_strategy` for official charts is a python executable file which can/cannot have flake8 errors. `upgrade_info.json` is a valid JSON file which is being used by `catalog_validation` to perform automatic upgrades. We add github actions here to validate both files to make sure they are valid.