### PR TITLE
"/admin/" is a non-existing path for Photoprism.

### DIFF
--- a/charts/photoprism/1.0.9/questions.yaml
+++ b/charts/photoprism/1.0.9/questions.yaml
@@ -20,7 +20,7 @@ portals:
       - "$node_ip"
     ports:
       - "$variable-web_port"
-    path: "/admin/"
+    path: "/"
 
 questions:
   - variable: web_port


### PR DESCRIPTION
"/admin/" is a non-existing path for Photoprism. "/" is the correct path.