### PR TITLE
pihole: Fix DHCP and HostNetwork

### DIFF
--- a/charts/pihole/1.0.12/questions.yaml
+++ b/charts/pihole/1.0.12/questions.yaml
@@ -65,6 +65,30 @@ questions:
       default: 20722
       required: true
       show_if: [["dhcp", "=", true]]
+  - variable: dhcp_start
+    label: "DHCP Start Address"
+    group: Networking
+    schema:
+      type: ipaddr
+      cidr: false
+      required: true
+      show_if: [["dhcp", "=", true]]
+  - variable: dhcp_end
+    label: "DHCP End Address"
+    group: Networking
+    schema:
+      type: ipaddr
+      cidr: false
+      required: true
+      show_if: [["dhcp", "=", true]]
+  - variable: dhcp_gateway
+    label: "Gateway"
+    group: Networking
+    schema:
+      type: ipaddr
+      cidr: false
+      required: true
+      show_if: [["dhcp", "=", true]]
 
   - variable: dnsConfig
     label: "DNS Configuration"

--- a/charts/pihole/1.0.12/templates/deployment.yaml
+++ b/charts/pihole/1.0.12/templates/deployment.yaml
@@ -39,7 +39,11 @@ spec:
           {{ end }}
           ports:
             - name: web
+              {{ if .Values.hostNetwork }}
+              containerPort: {{ .Values.web_port }}
+              {{ else }}
               containerPort: 80
+              {{ end }}
             - name: dns-tcp
               containerPort: 53
               protocol: TCP
@@ -61,6 +65,9 @@ spec:
             {{ $envList := (default list .Values.environmentVariables) }}
             {{ $envList = mustAppend $envList (dict "name" "WEBPASSWORD" "valueFromSecret" true "secretName" $secretName "secretKey" "password") }}
             {{ $envList = mustAppend $envList (dict "name" "TZ" "value" (printf "%s" .Values.timezone)) }}
+            {{ if .Values.hostNetwork }}
+            {{ $envList = mustAppend $envList (dict "name" "WEB_PORT" "value" .Values.web_port ) }}
+            {{ end }}
             {{ if .Values.dhcp }}
             {{ $envList = mustAppend $envList (dict "name" "DHCP_ACTIVE" "value" "true") }}
             {{ $envList = mustAppend $envList (dict "name" "DHCP_START" "value" .Values.dhcp_start) }}

--- a/charts/pihole/1.0.12/templates/deployment.yaml
+++ b/charts/pihole/1.0.12/templates/deployment.yaml
@@ -51,6 +51,11 @@ spec:
               containerPort: 67
               protocol: UDP
             {{ end }}
+          {{ if .Values.dhcp }}
+          securityContext:
+            capabilities:
+              add: ["NET_ADMIN"]
+          {{ end }}
           env:
             {{ $secretName := (include "common.names.fullname" .) }}
             {{ $envList := (default list .Values.environmentVariables) }}

--- a/charts/pihole/1.0.12/templates/deployment.yaml
+++ b/charts/pihole/1.0.12/templates/deployment.yaml
@@ -63,6 +63,9 @@ spec:
             {{ $envList = mustAppend $envList (dict "name" "TZ" "value" (printf "%s" .Values.timezone)) }}
             {{ if .Values.dhcp }}
             {{ $envList = mustAppend $envList (dict "name" "DHCP_ACTIVE" "value" "true") }}
+            {{ $envList = mustAppend $envList (dict "name" "DHCP_START" "value" .Values.dhcp_start) }}
+            {{ $envList = mustAppend $envList (dict "name" "DHCP_END" "value" .Values.dhcp_end) }}
+            {{ $envList = mustAppend $envList (dict "name" "DHCP_ROUTER" "value" .Values.dhcp_gateway) }}
             {{ end }}
             {{ include "common.containers.environmentVariables" (dict "environmentVariables" $envList) | nindent 12 }}
 {{ include "common.networking.dnsConfiguration" .Values | nindent 6 }}

--- a/charts/pihole/1.0.12/templates/deployment.yaml
+++ b/charts/pihole/1.0.12/templates/deployment.yaml
@@ -67,6 +67,7 @@ spec:
             {{ $envList = mustAppend $envList (dict "name" "TZ" "value" (printf "%s" .Values.timezone)) }}
             {{ if .Values.hostNetwork }}
             {{ $envList = mustAppend $envList (dict "name" "WEB_PORT" "value" .Values.web_port ) }}
+            {{ $envList = mustAppend $envList (dict "name" "DNSMASQ_LISTENING" "value" "all" ) }}
             {{ end }}
             {{ if .Values.dhcp }}
             {{ $envList = mustAppend $envList (dict "name" "DHCP_ACTIVE" "value" "true") }}

--- a/charts/pihole/1.0.12/templates/service.yaml
+++ b/charts/pihole/1.0.12/templates/service.yaml
@@ -2,12 +2,16 @@
 {{ $selectors = mustAppend $selectors (dict "key" "app" "value" (include "common.names.name" .) ) }}
 {{ $selectors = mustAppend $selectors (dict "key" "release" "value" .Release.Name ) }}
 {{ $ports := list }}
+{{ if .Values.hostNetwork }}
+{{ $ports = mustAppend $ports (dict "name" "web" "port" .Values.web_port "nodePort" .Values.web_port "targetPort" .Values.web_port) }}
+{{ else }}
 {{ $ports = mustAppend $ports (dict "name" "web" "port" .Values.web_port "nodePort" .Values.web_port "targetPort" 80) }}
 {{ $ports = mustAppend $ports (dict "name" "dns-tcp" "port" .Values.dns_tcp_port "nodePort" .Values.dns_tcp_port "targetPort" 53) }}
 {{ $ports = mustAppend $ports (dict "name" "dns-udp" "port" .Values.dns_udp_port "nodePort" .Values.dns_udp_port "targetPort" 53 "protocol" "UDP") }}
 {{ if .Values.dhcp }}
 {{ $ports = mustAppend $ports (dict "name" "dhcp" "port" .Values.dhcp_port "nodePort" .Values.dhcp_port "targetPort" 67 "protocol" "UDP") }}
 {{ end }}
+{{ end}}
 {{ $params := . }}
 {{ $_ := set $params "commonService" (dict "type" "NodePort" "ports" $ports ) }}
 {{ $_1 := set .Values "extraSelectorLabels" $selectors }}


### PR DESCRIPTION
There are several bugs that prevent pihole from being used as a DHCP server on the host's network.

- Pihole requires NET_ADMIN to enable DHCP.
- Pihole requires the start, end, and router address to be filled in to enable DHCP.
- When the pihole pod is started in the root networking namespace, port 80 is already taken by the TrueNAS webui.
- When the pihole pod is started in the root networking namespace, it only allow DHCP/DNS traffic over the eth0 interface. 

Fixing these issues allows pihole to function as a DHCP server for the host's network. To test this, enable DHCP server and enter the required fields and check the "Enable Host Network" checkbox.

![Screenshot from 2023-01-21 05-41-56](https://user-images.githubusercontent.com/16107760/213865356-3be374e1-b925-4bf6-bac6-27727c5b4c26.png)
