### PR TITLE
NAS-120131 / 23.10 / Fix catalog.json github action

### DIFF
--- a/.github/workflows/update_catalog.yaml
+++ b/.github/workflows/update_catalog.yaml
@@ -18,6 +18,9 @@ jobs:
       - name: Update catalog details
         run: |
           /bin/bash -c "PWD=${pwd}; /usr/local/bin/catalog_update update --path $PWD"
+      - name: Add catalog json as a safe directory
+        run: |
+          /bin/bash -c "PWD=${pwd}; git config --global --add safe.directory $PWD"
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
             commit_message: Update catalog information


### PR DESCRIPTION
## Problem

Auto commit github action for updating `catalog.json` is broken with recent upgrade of `catalog_validation` image. Following error is generated:

```
fatal: detected dubious ownership in repository at '/__w/charts/charts'
```

## Solution

This should be fixed by adding the git repo path to safe directory git global cofig path.