### PR TITLE
NAS-121181 / 23.10 / Use a noauth endpoint for syncthing probe

### DIFF
--- a/library/ix-dev/charts/syncthing/Chart.yaml
+++ b/library/ix-dev/charts/syncthing/Chart.yaml
@@ -3,7 +3,7 @@ description: Syncthing is a continuous file synchronization program.
 annotations:
   title: Syncthing
 type: application
-version: 1.0.19
+version: 1.0.20
 apiVersion: v2
 appVersion: '1.23.2'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/syncthing/templates/deployment.yaml
+++ b/library/ix-dev/charts/syncthing/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
               protocol: UDP
           readinessProbe:
             httpGet:
-              path: /
+              path: /rest/noauth/health
               port: 8384
             initialDelaySeconds: 10
             periodSeconds: 10
@@ -58,7 +58,7 @@ spec:
             successThreshold: 2
           livenessProbe:
             httpGet:
-              path: /
+              path: /rest/noauth/health
               port: 8384
             initialDelaySeconds: 10
             periodSeconds: 10
@@ -67,7 +67,7 @@ spec:
             successThreshold: 1
           startupProbe:
             httpGet:
-              path: /
+              path: /rest/noauth/health
               port: 8384
             initialDelaySeconds: 10
             periodSeconds: 5


### PR DESCRIPTION
Syncthing have basicAuth on `/` when enabled. So probes get `401` and report failure.
Changed the endpoint to a no-auth one