### PR TITLE
Fix pre-upgrade postgresBackup job and adds a template for postgres-wait

### DIFF
--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A library chart for iX Official Catalog
 type: library
-version: 1.0.0
+version: 1.0.1
 appVersion: v1
 annotations:
   title: Common Library Chart


### PR DESCRIPTION
- Before run the postgres backup pre-upgrade hook, check if the ixChartContext.isUpgrade is set. This is to avoid running pre-upgrade hook after starting the app from a stopped state. Which if we try to run will fail, as the postgres is not running, causing the backup job wait for ever for postgres to come online.
In case the `isUpgrade` key is missing completely (means we are not in SCALE system), there we run the pre-upgrade job normally, so we can let CI test that too.

- Adds a small template for including the postgres-wait container where needed