### PR TITLE
NAS-121368  (Minio)Add a default storage item and description on storage type 

### DIFF
--- a/library/ix-dev/enterprise/minio/Chart.yaml
+++ b/library/ix-dev/enterprise/minio/Chart.yaml
@@ -3,7 +3,7 @@ description: High Performance, Kubernetes Native Object Storage
 annotations:
   title: MinIO
 type: application
-version: 1.0.1
+version: 1.0.2
 apiVersion: v2
 appVersion: '2023-03-24'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/enterprise/minio/questions.yaml
+++ b/library/ix-dev/enterprise/minio/questions.yaml
@@ -187,9 +187,9 @@ questions:
                   default: ixVolume
                   enum:
                     - value: hostPath
-                      description: Host Path
+                      description: Host Path (Path that already exists on the system)
                     - value: ixVolume
-                      description: ixVolume
+                      description: ixVolume (Dataset created automatically by the system)
               - variable: mountPath
                 label: Mount Path
                 description: The path inside the container to mount the storage.

--- a/library/ix-dev/enterprise/minio/questions.yaml
+++ b/library/ix-dev/enterprise/minio/questions.yaml
@@ -166,7 +166,9 @@ questions:
     group: Storage Configuration
     schema:
       type: list
-      default: []
+      default: [{"type": "ixVolume", "mountPath": "/data1", "datasetName": "data1"}]
+      empty: false
+      required: true
       items:
         - variable: item
           label: Storage Item
@@ -175,6 +177,9 @@ questions:
             attrs:
               - variable: type
                 label: Type
+                description: |
+                  ixVolume: Is dataset created automatically by the system.</br>
+                  Host Path: Is a path that already exists on the system.
                 schema:
                   type: string
                   immutable: true


### PR DESCRIPTION
While a validation is performed on the chart side to prevent installing without storage, this PR:
Adds a default storage item, since at least 1 is required.
Also shortly explains what an ixVolume and a host path type is
