### PR TITLE
NAS-121262 / 23.10 / Set proper value types in values.yaml that match schema

### DIFF
--- a/library/ix-dev/community/chia/Chart.yaml
+++ b/library/ix-dev/community/chia/Chart.yaml
@@ -4,7 +4,7 @@ description: Chia is a modern cryptocurrency built from scratch, designed to be 
 annotations:
   title: Chia
 type: application
-version: 1.0.3
+version: 1.0.4
 apiVersion: v2
 appVersion: 1.7.1
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/chia/values.yaml
+++ b/library/ix-dev/community/chia/values.yaml
@@ -12,7 +12,7 @@ chiaNetwork:
 chiaConfig:
   service: ''
   farmer_address: ''
-  farmer_port: ''
+  farmer_port: 0
   ca: ''
   full_node_peer: ''
   additionalEnvs: []

--- a/library/ix-dev/community/vaultwarden/Chart.yaml
+++ b/library/ix-dev/community/vaultwarden/Chart.yaml
@@ -4,7 +4,7 @@ description: Alternative implementation of the Bitwarden server API written in R
 annotations:
   title: Vaultwarden
 type: application
-version: 1.0.2
+version: 1.0.3
 apiVersion: v2
 appVersion: '1.28.1'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/vaultwarden/values.yaml
+++ b/library/ix-dev/community/vaultwarden/values.yaml
@@ -17,7 +17,7 @@ vaultwardenNetwork:
   wsEnabled: true
   wsPort: 30001
   hostNetwork: false
-  certificateID: ''
+  certificateID: 0
   domain: ''
 
 vaultwardenRunAs:

--- a/library/ix-dev/enterprise/minio/Chart.yaml
+++ b/library/ix-dev/enterprise/minio/Chart.yaml
@@ -3,7 +3,7 @@ description: High Performance, Kubernetes Native Object Storage
 annotations:
   title: MinIO
 type: application
-version: 1.0.2
+version: 1.0.3
 apiVersion: v2
 appVersion: '2023-03-24'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/enterprise/minio/values.yaml
+++ b/library/ix-dev/enterprise/minio/values.yaml
@@ -24,7 +24,7 @@ minioRunAs:
 minioNetwork:
   apiPort: 30000
   webPort: 30001
-  certificateID: ''
+  certificateID: 0
   hostNetwork: false
   serverUrl: ''
   consoleUrl: ''


### PR DESCRIPTION
Only actually affected chart is `Chia`

`Minio` and `Vaultwarden` is not affected, as the certificateID is not hiddin in the UI and it gets set to `null` at install time.
But updating those now to keep everything consistent

Chart will work with both `''` and `0` as values there, as they are checked like this:
`if .Value.path.to.value` which results to false in both `''` and `0`