### PR TITLE
Add normalize/acl to features capability

### DIFF
--- a/features_capability.json
+++ b/features_capability.json
@@ -1,4 +1,8 @@
 {
+  "normalize/acl": {
+    "stable": {"min":  "23.10-ALPHA"},
+    "nightlies": {"min":  "23.10-MASTER-somever"}
+  },
   "normalize/interfaceConfiguration": {
     "stable": {"min":  "20.12-ALPHA"},
     "nightlies": {"min":  "20.10-MASTER-somever"}


### PR DESCRIPTION
## Context

Any new ref which has been introduced must be added to the features capability mapping we have so it can be tracked on middleware side for erroring out if user does not has necessary middleware changes in place to consume the chart/app.