### PR TITLE
NAS-121456 / 23.10 / Adds field for emptyDir `sizeLimit` to ix-chart

### DIFF
--- a/library/ix-dev/charts/ix-chart/Chart.yaml
+++ b/library/ix-dev/charts/ix-chart/Chart.yaml
@@ -10,6 +10,7 @@ kubeVersion: ">=1.16.0-0"
 maintainers:
   - name: truenas
     url: https://www.truenas.com/
+    email: dev@ixsystems.com
 dependencies:
   - name: common
     repository: file://../../../common/2304.0.1

--- a/library/ix-dev/charts/ix-chart/Chart.yaml
+++ b/library/ix-dev/charts/ix-chart/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart for deploying simple workloads Kubernetes
 annotations:
   title: ix-chart
 type: application
-version: 2304.0.3
+version: 2304.0.4
 apiVersion: v2
 appVersion: v1
 kubeVersion: ">=1.16.0-0"

--- a/library/ix-dev/charts/ix-chart/questions.yaml
+++ b/library/ix-dev/charts/ix-chart/questions.yaml
@@ -494,6 +494,7 @@ questions:
                   Format: 100Mi, 1Gi, 2Gi etc
                 schema:
                   type: string
+                  valid_chars: "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
 
   # Volumes
   - variable: volumes

--- a/library/ix-dev/charts/ix-chart/questions.yaml
+++ b/library/ix-dev/charts/ix-chart/questions.yaml
@@ -495,6 +495,7 @@ questions:
                 schema:
                   type: string
                   valid_chars: "^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
+                  default: "512Mi"
 
   # Volumes
   - variable: volumes

--- a/library/ix-dev/charts/ix-chart/questions.yaml
+++ b/library/ix-dev/charts/ix-chart/questions.yaml
@@ -487,6 +487,13 @@ questions:
                 schema:
                   type: path
                   required: true
+              - variable: sizeLimit
+                label: "Size Limit"
+                description: |
+                  Optional - Size of the memory backed volume.</br>
+                  Format: 100Mi, 1Gi, 2Gi etc
+                schema:
+                  type: string
 
   # Volumes
   - variable: volumes

--- a/library/ix-dev/charts/ix-chart/templates/_volumes.tpl
+++ b/library/ix-dev/charts/ix-chart/templates/_volumes.tpl
@@ -23,6 +23,9 @@ volumes:
   - name: ix-emptydir-volume-{{ $.Release.Name }}-{{ $index }}
     emptyDir:
       medium: Memory
+      {{- with $emptyDirConfiguration.sizeLimit }}
+      sizeLimit: {{ . }}
+      {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Adds a field for sizeLimit on memory backed volumes. It's an optional field