### PR TITLE
Reduce the min allowed user for `runAs`

### DIFF
--- a/library/ix-dev/community/lidarr/Chart.yaml
+++ b/library/ix-dev/community/lidarr/Chart.yaml
@@ -3,7 +3,7 @@ description: Lidarr is a music collection manager for Usenet and BitTorrent user
 annotations:
   title: Lidarr
 type: application
-version: 1.0.2
+version: 1.0.3
 apiVersion: v2
 appVersion: '1.1.3.2982'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/lidarr/questions.yaml
+++ b/library/ix-dev/community/lidarr/questions.yaml
@@ -68,7 +68,7 @@ questions:
           description: The user id that Lidarr will run as.
           schema:
             type: int
-            min: 568
+            min: 2
             default: 568
             required: true
         - variable: group
@@ -76,7 +76,7 @@ questions:
           description: The group id that Lidarr will run as.
           schema:
             type: int
-            min: 568
+            min: 2
             default: 568
             required: true
 

--- a/library/ix-dev/community/qbittorrent/Chart.yaml
+++ b/library/ix-dev/community/qbittorrent/Chart.yaml
@@ -3,7 +3,7 @@ description: The qBittorrent project aims to provide an open-source software alt
 annotations:
   title: qBittorrent
 type: application
-version: 1.0.4
+version: 1.0.5
 apiVersion: v2
 appVersion: '4.5.2'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/qbittorrent/questions.yaml
+++ b/library/ix-dev/community/qbittorrent/questions.yaml
@@ -61,7 +61,7 @@ questions:
           description: The user id that qBittorrent will run as.
           schema:
             type: int
-            min: 568
+            min: 2
             default: 568
             required: true
         - variable: group
@@ -69,7 +69,7 @@ questions:
           description: The group id that qBittorrent will run as.
           schema:
             type: int
-            min: 568
+            min: 2
             default: 568
             required: true
 

--- a/library/ix-dev/community/radarr/Chart.yaml
+++ b/library/ix-dev/community/radarr/Chart.yaml
@@ -3,7 +3,7 @@ description: Radarr is a movie collection manager for Usenet and BitTorrent user
 annotations:
   title: Radarr
 type: application
-version: 1.0.4
+version: 1.0.5
 apiVersion: v2
 appVersion: 4.4.4.7068
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/radarr/questions.yaml
+++ b/library/ix-dev/community/radarr/questions.yaml
@@ -68,7 +68,7 @@ questions:
           description: The user id that Radarr will run as.
           schema:
             type: int
-            min: 568
+            min: 2
             default: 568
             required: true
         - variable: group
@@ -76,7 +76,7 @@ questions:
           description: The group id that Radarr will run as.
           schema:
             type: int
-            min: 568
+            min: 2
             default: 568
             required: true
 

--- a/library/ix-dev/community/sonarr/Chart.yaml
+++ b/library/ix-dev/community/sonarr/Chart.yaml
@@ -3,7 +3,7 @@ description: Sonarr is a PVR for Usenet and BitTorrent users.
 annotations:
   title: Sonarr
 type: application
-version: 1.0.2
+version: 1.0.3
 apiVersion: v2
 appVersion: '3.0.10.1567'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/sonarr/questions.yaml
+++ b/library/ix-dev/community/sonarr/questions.yaml
@@ -68,7 +68,7 @@ questions:
           description: The user id that Sonarr will run as.
           schema:
             type: int
-            min: 1
+            min: 2
             default: 568
             required: true
         - variable: group
@@ -76,7 +76,7 @@ questions:
           description: The group id that Sonarr will run as.
           schema:
             type: int
-            min: 1
+            min: 2
             default: 568
             required: true
 


### PR DESCRIPTION
We previously increased the `min` user/group to 568 which is in most cases fine, but there are [cases](https://github.com/truenas/charts/commit/2e4d29ecf649c0c4550c02c5473a074717ea0485#commitcomment-110133548) that you need to set it to a lower id.
This PR reduces the `min` user/group to `2`.

Apps `minio`, `vaultwarden`, `ipfs` and `prometheus` are left as is with `min` as `568`, as the data created by each app are not meant to be accessed by other apps at the same time

(TL;DR only "media" apps are changed)
