### PR TITLE
NAS-121749 / 23.10 / Apply a partial fix for hostnetwork toggling

### DIFF
--- a/library/common-test/Chart.yaml
+++ b/library/common-test/Chart.yaml
@@ -16,3 +16,4 @@ dependencies:
 maintainers:
   - name: truenas
     url: https://www.truenas.com/
+    email: dev@ixsystems.com

--- a/library/common-test/tests/container/ports_test.yaml
+++ b/library/common-test/tests/container/ports_test.yaml
@@ -61,6 +61,7 @@ tests:
             ports:
               - name: port-name
                 containerPort: 80
+                hostPort: null
                 protocol: TCP
       - documentIndex: &otherDeploymentDoc 1
         isKind:
@@ -135,6 +136,7 @@ tests:
             ports:
               - name: port-name
                 containerPort: 1234
+                hostPort: null
                 protocol: TCP
       - documentIndex: &otherDeploymentDoc 1
         isKind:
@@ -146,6 +148,7 @@ tests:
             ports:
               - name: port-name
                 containerPort: 53
+                hostPort: null
                 protocol: TCP
 
   - it: should create the correct ports with hostPort
@@ -237,6 +240,7 @@ tests:
             ports:
               - name: port-name
                 containerPort: 1234
+                hostPort: null
                 protocol: TCP
 
   - it: should create the correct protocol
@@ -281,4 +285,5 @@ tests:
             ports:
               - name: port-name
                 containerPort: 1234
+                hostPort: null
                 protocol: UDP

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -9,3 +9,4 @@ annotations:
 maintainers:
   - name: truenas
     url: https://www.truenas.com/
+    email: dev@ixsystems.com

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A library chart for iX Official Catalog
 type: library
-version: 1.0.6
+version: 1.0.7
 appVersion: v1
 annotations:
   title: Common Library Chart

--- a/library/common/templates/lib/container/_ports.tpl
+++ b/library/common/templates/lib/container/_ports.tpl
@@ -81,7 +81,7 @@ objectData: The object data to be used to render the container.
 
 {{- end -}}
 {{/* Turning hostNetwork on, it creates hostPort automatically and turning it back off does not remove them. Setting hostPort explicitly to null will remove them.
-    There are still cases that hostPort is not removed, for example, if you have a TCP and UDP port with the same number. Only the TCP's hostPort will be removed.
+    There are still cases that hostPort is not removed, for example, if you have a TCP and UDP port with the same number. Only the TCPs hostPort will be removed.
     Also note that setting hostPort to null always, it will NOT affect hostNetwork, as it will still create the hostPorts.
     It only helps to remove them when hostNetwork is turned off.
 */}}

--- a/library/common/templates/lib/container/_ports.tpl
+++ b/library/common/templates/lib/container/_ports.tpl
@@ -81,7 +81,7 @@ objectData: The object data to be used to render the container.
 
 {{- end -}}
 {{/* Turning hostNetwork on, it creates hostPort automatically and turning it back off does not remove them. Setting hostPort explicitly to null will remove them.
-    There are still cases that hostPort is not removed, for example, if you have a TCP and UDP port with the same number. Only the TCPs hostPort will be removed.
-    Also note that setting hostPort to null always, it will NOT affect hostNetwork, as it will still create the hostPorts.
-    It only helps to remove them when hostNetwork is turned off.
+    There are still cases that hostPort is not removed, for example, if you have a TCP and UDP port with the same port number. Only the one of the hostPorts will
+    be removed. This is due to how merging is happening, (See kubernetes/kubernetes#105610). Also note that setting hostPort to null always, it will NOT affect
+    hostNetwork, as it will still create the hostPorts. It only helps to remove them when hostNetwork is turned off.
 */}}

--- a/library/common/templates/lib/container/_ports.tpl
+++ b/library/common/templates/lib/container/_ports.tpl
@@ -45,7 +45,7 @@ objectData: The object data to be used to render the container.
             {{- end -}}
 
           {{- else -}}
-            {{/* If no selector is defined but contaienr is primary */}}
+            {{/* If no selector is defined but container is primary */}}
             {{- if $objectData.primary -}}
               {{- $containerSelected = true -}}
             {{- end -}}
@@ -68,8 +68,10 @@ objectData: The object data to be used to render the container.
 - name: {{ $portName }}
   containerPort: {{ $containerPort }}
   protocol: {{ $protocol | upper }}
-        {{- with $portValues.hostPort }}
+          {{- with $portValues.hostPort }}
   hostPort: {{ . }}
+          {{- else }}
+  hostPort: null
           {{- end -}}
         {{- end -}}
 
@@ -78,3 +80,8 @@ objectData: The object data to be used to render the container.
   {{- end -}}
 
 {{- end -}}
+{{/* Turning hostNetwork on, it creates hostPort automatically and turning it back off does not remove them. Setting hostPort explicitly to null will remove them.
+    There are still cases that hostPort is not removed, for example, if you have a TCP and UDP port with the same number. Only the TCP's hostPort will be removed.
+    Also note that setting hostPort to null always, it will NOT affect hostNetwork, as it will still create the hostPorts.
+    It only helps to remove them when hostNetwork is turned off.
+*/}}

--- a/library/ix-dev/charts/emby/Chart.yaml
+++ b/library/ix-dev/charts/emby/Chart.yaml
@@ -3,7 +3,7 @@ description: Emby Server
 annotations:
   title: Emby Server
 type: application
-version: 1.0.22
+version: 1.0.23
 apiVersion: v2
 appVersion: '4.7.11.0'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/emby/templates/deployment.yaml
+++ b/library/ix-dev/charts/emby/templates/deployment.yaml
@@ -31,12 +31,21 @@ spec: {{ include "common.deployment.common_spec" . | nindent 2 }}
           - name: emby
             protocol: TCP
             containerPort: 8096
+          {{- if not .Values.hostNetwork }}
+            hostPort: null
+          {{- end }}
           - name: emby-dlna
             protocol: UDP
             containerPort: 1900
+          {{- if not .Values.hostNetwork }}
+            hostPort: null
+          {{- end }}
           - name: emby-lnd
             protocol: UDP
             containerPort: 7359
+          {{- if not .Values.hostNetwork }}
+            hostPort: null
+          {{- end }}
           env:
             - name: KUBE_NAMESPACE
               valueFrom:

--- a/library/ix-dev/charts/home-assistant/Chart.yaml
+++ b/library/ix-dev/charts/home-assistant/Chart.yaml
@@ -3,7 +3,7 @@ description: Home Assistant App for TrueNAS SCALE
 annotations:
   title: Home Assistant
 type: application
-version: 1.0.88
+version: 1.0.89
 apiVersion: v2
 appVersion: 2023.5.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/home-assistant/templates/deployment.yaml
+++ b/library/ix-dev/charts/home-assistant/templates/deployment.yaml
@@ -71,6 +71,9 @@ spec:
           ports:
             - name: web
               containerPort: 8123
+            {{- if not .Values.hostNetwork }}
+              hostPort: null
+            {{- end }}
           readinessProbe:
             tcpSocket:
               port: 8123

--- a/library/ix-dev/charts/plex/Chart.yaml
+++ b/library/ix-dev/charts/plex/Chart.yaml
@@ -3,7 +3,7 @@ description: Plex Media Server
 annotations:
   title: Plex
 type: application
-version: 1.7.44
+version: 1.7.45
 apiVersion: v2
 appVersion: 1.32.1.6999
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/plex/templates/deployment.yaml
+++ b/library/ix-dev/charts/plex/templates/deployment.yaml
@@ -37,25 +37,45 @@ spec: {{ include "common.deployment.common_spec" . | nindent 2 }}
             containerPort: 32400
           {{- if .Values.hostNetwork }}
             hostPort: {{ .Values.plexServiceTCP.port }}
+          {{- else }}
+            hostPort: null
           {{- end }}
           - name: plex-dlna
             protocol: TCP
             containerPort: 32469
+          {{- if not .Values.hostNetwork }}
+            hostPort: null
+          {{- end }}
           - name: plex-dlna-udp
             protocol: UDP
             containerPort: 1900
+          {{- if not .Values.hostNetwork }}
+            hostPort: null
+          {{- end }}
           - name: plex-gdm1
             protocol: UDP
             containerPort: 32410
+          {{- if not .Values.hostNetwork }}
+            hostPort: null
+          {{- end }}
           - name: plex-gdm2
             protocol: UDP
             containerPort: 32412
+          {{- if not .Values.hostNetwork }}
+            hostPort: null
+          {{- end }}
           - name: plex-gdm3
             protocol: UDP
             containerPort: 32413
+          {{- if not .Values.hostNetwork }}
+            hostPort: null
+          {{- end }}
           - name: plex-gdm4
             protocol: UDP
             containerPort: 32414
+          {{- if not .Values.hostNetwork }}
+            hostPort: null
+          {{- end }}
           env:
             - name: KUBE_NAMESPACE
               valueFrom:

--- a/library/ix-dev/charts/syncthing/Chart.yaml
+++ b/library/ix-dev/charts/syncthing/Chart.yaml
@@ -3,7 +3,7 @@ description: Syncthing is a continuous file synchronization program.
 annotations:
   title: Syncthing
 type: application
-version: 1.0.25
+version: 1.0.26
 apiVersion: v2
 appVersion: 1.23.4
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/syncthing/templates/deployment.yaml
+++ b/library/ix-dev/charts/syncthing/templates/deployment.yaml
@@ -41,12 +41,21 @@ spec:
           ports:
             - name: web
               containerPort: 8384
+              {{ if not .Values.hostNetwork }}
+              hostPort: null
+              {{ end }}
             - name: tcp
               containerPort: 22000
               protocol: TCP
+              {{ if not .Values.hostNetwork }}
+              hostPort: null
+              {{ end }}
             - name: udp
               containerPort: 22000
               protocol: UDP
+              {{ if not .Values.hostNetwork }}
+              hostPort: null
+              {{ end }}
           readinessProbe:
             httpGet:
               path: /rest/noauth/health

--- a/library/ix-dev/charts/wg-easy/Chart.yaml
+++ b/library/ix-dev/charts/wg-easy/Chart.yaml
@@ -3,7 +3,7 @@ description: WG-Easy is the easiest way to install & manage WireGuard!
 annotations:
   title: WG Easy
 type: application
-version: 1.0.5
+version: 1.0.6
 apiVersion: v2
 appVersion: "7"
 kubeVersion: ">=1.16.0-0"

--- a/library/ix-dev/charts/wg-easy/templates/deployment.yaml
+++ b/library/ix-dev/charts/wg-easy/templates/deployment.yaml
@@ -50,8 +50,14 @@ spec:
             - name: udp
               containerPort: {{ .Values.wgUDPPort }}
               protocol: UDP
+            {{- if not .Values.hostNetwork }}
+              hostPort: null
+            {{- end }}
             - name: web
               containerPort: {{ .Values.webUIPort }}
+            {{- if not .Values.hostNetwork }}
+              hostPort: null
+            {{- end }}
           env:
             {{ $wgeasy := .Values.wgeasy }}
             {{ $envList := (default list .Values.environmentVariables) }}


### PR DESCRIPTION
This is a partial fix for an issue that appears after enabling hostNetwork and then disabling it.
I did a small "writeup" here, in a k3s discussions. 
https://github.com/k3s-io/k3s/discussions/6289#discussioncomment-5760503 (Check my comment)

(This is not a 100% fix for apps that have TCP and UDP ports with matching number. Check the link above)
Partially solves #1125
Should also help with #1001

> This can't be really fully unit tested fully as the generated manifests from Helm does not contain any hostPort values when hostNetwork is enabled. Those are added by k8s

Also note that apps that uses the same containerPort for multiple protocols (like Syncthing + port 22000). Cannot be "fixed".