### PR TITLE
NAS-121758 / 23.10 / Change default NodePort for storj

### DIFF
--- a/library/ix-dev/charts/storj/Chart.yaml
+++ b/library/ix-dev/charts/storj/Chart.yaml
@@ -3,7 +3,7 @@ description: Share your storage on the internet and earn.
 annotations:
   title: Storj
 type: application
-version: 1.0.9
+version: 1.0.10
 apiVersion: v2
 appVersion: v1.68.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/storj/questions.yaml
+++ b/library/ix-dev/charts/storj/questions.yaml
@@ -32,12 +32,16 @@ questions:
       required: true
   - variable: nodePort
     label: "Node Port for Storj"
+    description: |
+      This port will be used for both TCP and UDP traffic. </br>
+      Note that this port must be open on your firewall and that internal
+      Storj port will not be affected by this change, but only the external (Node Port)
     group: Networking
     schema:
       type: int
       min: 9000
       max: 65535
-      default: 20988
+      default: 28967
       required: true
 
   - variable: dnsConfig


### PR DESCRIPTION
With the "mismatch" of external and internal ports users was not sure what ports they have to forward in their network in order to get Storj app to work at its fullest capacity. Storj web UI was mentioning that user have to port foward port 28967, but in reality user should forward the port configured in the TrueNAS UI (NodePort).

Matching nodePort with containerPort will at least make easier for new users to forward the correct port