### PR TITLE
Remove 20 char limit for the vaultwarden admin token

### DIFF
--- a/library/ix-dev/community/vaultwarden/Chart.yaml
+++ b/library/ix-dev/community/vaultwarden/Chart.yaml
@@ -4,7 +4,7 @@ description: Alternative implementation of the Bitwarden server API written in R
 annotations:
   title: Vaultwarden
 type: application
-version: 1.0.6
+version: 1.0.7
 apiVersion: v2
 appVersion: '1.28.1'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/vaultwarden/questions.yaml
+++ b/library/ix-dev/community/vaultwarden/questions.yaml
@@ -41,7 +41,6 @@ questions:
           schema:
             type: string
             private: true
-            max_length: 20
             default: ""
         - variable: additionalEnvs
           label: Additional Environment Variables


### PR DESCRIPTION
Hashed tokens (as per recommendation) will exceed the imposed 20 char limit.

Also see [Enabling admin page - Secure the `ADMIN_TOKEN`](https://github.com/dani-garcia/vaultwarden/wiki/Enabling-admin-page#secure-the-admin_token)