### PR TITLE
NAS-121925 / 23.10 / Fix gpu assignment on multi gpu systems.

### DIFF
--- a/library/ix-dev/community/jellyfin/Chart.yaml
+++ b/library/ix-dev/community/jellyfin/Chart.yaml
@@ -3,7 +3,7 @@ description: Jellyfin is a Free Software Media System that puts you in control o
 annotations:
   title: Jellyfin
 type: application
-version: 1.0.1
+version: 1.0.2
 apiVersion: v2
 appVersion: '10.8.10'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/jellyfin/ci/basic-values.yaml
+++ b/library/ix-dev/community/jellyfin/ci/basic-values.yaml
@@ -17,6 +17,8 @@ jellyfinStorage:
     medium: Memory
     size: 1Gi
 
-# TODO: Test on a GPU-enabled system
-# jellyfinGPU:
-#   nvidia.com/gpu: 1
+# Make sure installation don't fail when 0 GPU are assigned
+jellyfinGPU:
+  nvidia.com/gpu: 0
+  intel.com/gpu: 0
+# TODO: Test assigning GPUs on a GPU-enabled system

--- a/library/ix-dev/community/jellyfin/templates/_jellyfin.tpl
+++ b/library/ix-dev/community/jellyfin/templates/_jellyfin.tpl
@@ -125,14 +125,13 @@ persistence:
           mountPath: /mnt/directories{{ $storage.mountPath }}
   {{- end }}
 {{ with .Values.jellyfinGPU }}
-  {{ if gt (. | len) 1 }}
-    {{- fail "Jellyfin - Max [1] GPUs allowed" -}}
-  {{ end }}
 scaleGPU:
+  {{ range $key, $value := . }}
   - gpu:
-      {{ . | keys | first }}: {{ . | values | first }}
+      {{ $key }}: {{ $value }}
     targetSelector:
       jellyfin:
         - jellyfin
+  {{ end }}
 {{ end }}
 {{- end -}}

--- a/library/ix-dev/community/tdarr/Chart.yaml
+++ b/library/ix-dev/community/tdarr/Chart.yaml
@@ -3,7 +3,7 @@ description: Tdarr is a Distributed Transcoding System
 annotations:
   title: Tdarr
 type: application
-version: 1.0.3
+version: 1.0.4
 apiVersion: v2
 appVersion: '2.00.20.1'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/tdarr/ci/basic-values.yaml
+++ b/library/ix-dev/community/tdarr/ci/basic-values.yaml
@@ -17,3 +17,7 @@ tdarrStorage:
     type: emptyDir
     medium: Memory
     size: 1Gi
+# Make sure installation don't fail when 0 GPU are assigned
+tdarrGPU:
+  nvidia.com/gpu: 0
+  intel.com/gpu: 0

--- a/library/ix-dev/community/tdarr/templates/_tdarr.tpl
+++ b/library/ix-dev/community/tdarr/templates/_tdarr.tpl
@@ -131,14 +131,13 @@ persistence:
   {{- end }}
 
 {{ with .Values.tdarrGPU }}
-  {{ if gt (. | len) 1 }}
-    {{- fail "Tdarr - Max [1] GPUs allowed" -}}
-  {{ end }}
 scaleGPU:
+  {{ range $key, $value := . }}
   - gpu:
-      {{ . | keys | first }}: {{ . | values | first }}
+      {{ $key }}: {{ $value }}
     targetSelector:
       tdarr:
         - tdarr
+  {{ end }}
 {{ end }}
 {{- end -}}


### PR DESCRIPTION
Fixes #1196 

Previous check was checking only the count of the keys present int he GPU dict.
But on multi-gpu systems, can be more than 1 key, (eg intel + nvidia).

> Note: common already takes care of `0` on a gpu assigment.
So we don't need to check if the value of each is is `> 0`.Common will only apply the GPU in resources if it's `1` or more.