### PR TITLE
NAS-122251 / 23.10 / [Nextcloud] Only set OVERWRITEHOST if both host and port are defined

### DIFF
--- a/library/ix-dev/charts/nextcloud/Chart.yaml
+++ b/library/ix-dev/charts/nextcloud/Chart.yaml
@@ -4,7 +4,7 @@ description: A file sharing server that puts the control and security of your ow
 annotations:
   title: Nextcloud
 type: application
-version: 1.6.28
+version: 1.6.29
 apiVersion: v2
 appVersion: 26.0.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/nextcloud/templates/deployment.yaml
+++ b/library/ix-dev/charts/nextcloud/templates/deployment.yaml
@@ -79,7 +79,9 @@ spec: {{ include "common.deployment.common_spec" . | nindent 2 }}
         {{ $envList = mustAppend $envList (dict "name" "NEXTCLOUD_DATA_DIR" "value" .Values.nextcloud.datadir) }}
         {{ if eq (include "nginx.certAvailable" .) "true" }}
         {{ $envList = mustAppend $envList (dict "name" "APACHE_DISABLE_REWRITE_IP" "value" "1") }}
+          {{ if and .Values.nextcloud.host .Values.service.nodePort }}
         {{ $envList = mustAppend $envList (dict "name" "OVERWRITEHOST" "value" (printf "%v:%v" .Values.nextcloud.host .Values.service.nodePort)) }}
+          {{ end }}
         {{ $envList = mustAppend $envList (dict "name" "OVERWRITEPROTOCOL" "value" "https") }}
         {{ $envList = mustAppend $envList (dict "name" "TRUSTED_PROXIES" "value" "127.0.0.1") }}
         {{ end }}


### PR DESCRIPTION
There are cases where someone could setup a proxy infront of nextcloud but still have ssl termination handled by the app.
In this case `OVERWRITEHOST` needs to be set to the domain and port the proxy is on.

Since we already don't `require` the nextcloud host to be set, when it's not given, lets skip setting `OVERWRITEHOST` variable and allow user add an additional env variable to set this. 

Fixes #1151