### PR TITLE
fix jenkins upgrade strategy

### DIFF
--- a/library/ix-dev/community/jenkins/Chart.yaml
+++ b/library/ix-dev/community/jenkins/Chart.yaml
@@ -3,7 +3,7 @@ description: Jenkins is a leading open source automation server,
 annotations:
   title: Jenkins
 type: application
-version: 1.0.0
+version: 1.0.1
 apiVersion: v2
 appVersion: '2.401.1'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/jenkins/upgrade_strategy
+++ b/library/ix-dev/community/jenkins/upgrade_strategy
@@ -11,7 +11,7 @@ RE_STABLE_VERSION = re.compile(r'[0-9]+\.[0-9]+\.[0-9]+-jdk17')
 
 def newer_mapping(image_tags):
     key = list(image_tags.keys())[0]
-    tags = {t.strip('-jdk17'): t for t in image_tags[key] if RE_STABLE_VERSION.fullmatch(t)}
+    tags = {t.replace('-jdk17', ''): t for t in image_tags[key] if RE_STABLE_VERSION.fullmatch(t)}
     version = semantic_versioning(list(tags))
     if not version:
         return {}


### PR DESCRIPTION
`.strip('...')` strips all occurrences of each character inside.
Which was converting `2.401.1` to `2.401.` and making previous tags appear "newer" eg `2.399.5`

Changed it to `replace('...', '')` and now works as it should.