### PR TITLE
NAS-122573 / 23.10 / minio portal fix + hostnet enabled by default

### DIFF
--- a/library/ix-dev/enterprise/minio/Chart.yaml
+++ b/library/ix-dev/enterprise/minio/Chart.yaml
@@ -3,7 +3,7 @@ description: High Performance, Kubernetes Native Object Storage
 annotations:
   title: MinIO
 type: application
-version: 1.0.11
+version: 1.0.12
 apiVersion: v2
 appVersion: '2023-03-24'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/enterprise/minio/questions.yaml
+++ b/library/ix-dev/enterprise/minio/questions.yaml
@@ -120,17 +120,17 @@ questions:
           description: |
             The URL that console will use to reach API</br>
             For example https;//minio1.example.com.</br></br>
-            This field is optional.
           schema:
             type: string
+            required: true
         - variable: consoleUrl
           label: MinIO Browser Redirect URL
           description: |
             The URL that console will provide as a redirect URL</br>
             For example https;//console.example.com.</br></br>
-            This field is optional.
           schema:
             type: string
+            required: true
 
   - variable: enableMultiMode
     label: Enable Multi Mode (SNMD or MNMD)

--- a/library/ix-dev/enterprise/minio/questions.yaml
+++ b/library/ix-dev/enterprise/minio/questions.yaml
@@ -106,7 +106,7 @@ questions:
             Bind to the host network. It's recommended to keep this disabled.</br>
           schema:
             type: boolean
-            default: false
+            default: true
         - variable: certificateID
           label: Certificate
           description: The certificate to use for MinIO

--- a/library/ix-dev/enterprise/minio/templates/_portal.tpl
+++ b/library/ix-dev/enterprise/minio/templates/_portal.tpl
@@ -5,35 +5,16 @@ kind: ConfigMap
 metadata:
   name: portal
 data:
-  {{- $host := .Values.minioNetwork.consoleUrl | default "$node_ip" -}}
-  {{- $protocol := "http" -}}
-
-  {{/* Extract protocol from user defined URL */}}
-  {{- $protocol := regexReplaceAll "(.*)://.*" $host "${1}" -}}
-  {{- if not $protocol -}}
-    {{/* If no protocol found, default to http */}}
-    {{- $protocol = "http" -}}
-  {{- end -}}
-
-  {{/* If we user used SCALE certificate, then force https */}}
+  {{- $url := urlParse .Values.minioNetwork.consoleUrl -}}
+  {{- $protocol := $url.scheme -}}
+  {{- $host := $url.hostname -}}
+  {{- $port := $url.host | replace $host "" | replace ":" "" -}}
+  {{/* If user used SCALE certificate, then force https */}}
   {{- if eq "https" (include "minio.scheme" $) -}}
     {{- $protocol = "https" -}}
-  {{- end -}}
-
-  {{/* Extract host with port from user defined URL */}}
-  {{- $host := regexReplaceAll ".*://(.*)" $host "${1}" -}}
-
-  {{/* Extract port from user defined URL */}}
-  {{- $port := regexReplaceAll ".*:(.*)" $host "${1}" -}}
-  {{- if not $port -}}
-    {{/* If no port is defined, use the minio port */}}
-    {{- $port = .Values.minioNetwork.webPort -}}
-  {{- end -}}
-
-  {{/* Extract host without port from user defined URL */}}
-  {{- $host = regexReplaceAll "(.*):.*" $host "${1}" }}
+  {{- end }}
   path: "/"
-  port: {{ $port | quote }}
-  protocol: {{ $protocol }}
-  host: {{ $host }}
+  port: {{ $port | default .Values.minioNetwork.webPort | quote }}
+  protocol: {{ $protocol | default "http" }}
+  host: {{ $host | default "$node_ip" }}
 {{- end -}}

--- a/library/ix-dev/enterprise/minio/templates/_portal.tpl
+++ b/library/ix-dev/enterprise/minio/templates/_portal.tpl
@@ -6,10 +6,34 @@ metadata:
   name: portal
 data:
   {{- $host := .Values.minioNetwork.consoleUrl | default "$node_ip" -}}
-  {{- $host = $host | replace "https://" "" -}}
-  {{- $host = $host | replace "http://" "" }}
+  {{- $protocol := "http" -}}
+
+  {{/* Extract protocol from user defined URL */}}
+  {{- $protocol := regexReplaceAll "(.*)://.*" $host "${1}" -}}
+  {{- if not $protocol -}}
+    {{/* If no protocol found, default to http */}}
+    {{- $protocol = "http" -}}
+  {{- end -}}
+
+  {{/* If we user used SCALE certificate, then force https */}}
+  {{- if eq "https" (include "minio.scheme" $) -}}
+    {{- $protocol = "https" -}}
+  {{- end -}}
+
+  {{/* Extract host with port from user defined URL */}}
+  {{- $host := regexReplaceAll ".*://(.*)" $host "${1}" -}}
+
+  {{/* Extract port from user defined URL */}}
+  {{- $port := regexReplaceAll ".*:(.*)" $host "${1}" -}}
+  {{- if not $port -}}
+    {{/* If no port is defined, use the minio port */}}
+    {{- $port = .Values.minioNetwork.webPort -}}
+  {{- end -}}
+
+  {{/* Extract host without port from user defined URL */}}
+  {{- $host = regexReplaceAll "(.*):.*" $host "${1}" }}
   path: "/"
-  port: {{ .Values.minioNetwork.webPort | quote }}
-  protocol: {{ include "minio.scheme" $ }}
+  port: {{ $port | quote }}
+  protocol: {{ $protocol }}
   host: {{ $host }}
 {{- end -}}

--- a/library/ix-dev/enterprise/minio/values.yaml
+++ b/library/ix-dev/enterprise/minio/values.yaml
@@ -25,7 +25,7 @@ minioNetwork:
   apiPort: 30000
   webPort: 30001
   certificateID: 0
-  hostNetwork: false
+  hostNetwork: true
   serverUrl: ''
   consoleUrl: ''
 


### PR DESCRIPTION
In order for minio to create the "Share" url's correctly, server + console url have to be defined. Otherwise it will use the loopback.

> (Assuming the URLs resolve to host IP)

Defining those URLs minio frontend will fail to communicate with the API. because it will try to reach the host IP from inside the container. So in order to work we can set hostnetwork to true by default, which will allow minio frontend to reach API from the URLs configured.

> Also fixed portal generation logic as it was appending port twice in some cases