### PR TITLE
NAS-122651 / 23.10 / hide webport when hostnetwork is enabled

### DIFF
--- a/library/ix-dev/community/jellyfin/Chart.yaml
+++ b/library/ix-dev/community/jellyfin/Chart.yaml
@@ -3,7 +3,7 @@ description: Jellyfin is a Free Software Media System that puts you in control o
 annotations:
   title: Jellyfin
 type: application
-version: 1.0.6
+version: 1.0.7
 apiVersion: v2
 appVersion: '10.8.10'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/jellyfin/questions.yaml
+++ b/library/ix-dev/community/jellyfin/questions.yaml
@@ -85,15 +85,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: webPort
-          label: Web Port
-          description: The port for the Jellyfin Web UI.
-          schema:
-            type: int
-            default: 30013
-            min: 9000
-            max: 65535
-            required: true
         - variable: hostNetwork
           label: Host Network
           description: |
@@ -102,6 +93,16 @@ questions:
           schema:
             type: boolean
             default: false
+        - variable: webPort
+          label: Web Port
+          description: The port for the Jellyfin Web UI.
+          schema:
+            type: int
+            default: 30013
+            show_if: [["hostNetwork", "=", false]]
+            min: 9000
+            max: 65535
+            required: true
 
   - variable: jellyfinStorage
     label: ""

--- a/library/ix-dev/community/jellyfin/templates/_portal.tpl
+++ b/library/ix-dev/community/jellyfin/templates/_portal.tpl
@@ -6,7 +6,11 @@ metadata:
   name: portal
 data:
   path: "/"
-  port: {{ .Values.jellyfinNetwork.webPort | quote }}
+  {{- $port := .Values.jellyfinNetwork.webPort -}}
+  {{- if .Values.jellyfinNetwork.hostNetwork -}}
+    {{- $port = 8096 -}}
+  {{- end }}
+  port: {{ $port | quote }}
   protocol: http
   host: $node_ip
 {{- end -}}


### PR DESCRIPTION
Fixes #1296

As we cannot alter the internal Jellyfin port, we shouldn't show the port configuration field when hostnetwork is enabled.