### PR TITLE
NAS-122858 / 23.10 / Add support for additional library mounts in immich

### DIFF
--- a/library/ix-dev/community/immich/Chart.yaml
+++ b/library/ix-dev/community/immich/Chart.yaml
@@ -3,7 +3,7 @@ description: Immich
 annotations:
   title: Immich
 type: application
-version: 1.0.1
+version: 1.0.2
 apiVersion: v2
 appVersion: '1.66.1'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/immich/ci/extra-values.yaml
+++ b/library/ix-dev/community/immich/ci/extra-values.yaml
@@ -1,0 +1,25 @@
+immichStorage:
+  uploads:
+    type: hostPath
+    hostPath: /mnt/{{ .Release.Name }}/uploads
+  library:
+    type: hostPath
+    hostPath: /mnt/{{ .Release.Name }}/library
+  thumbs:
+    type: hostPath
+    hostPath: /mnt/{{ .Release.Name }}/thumbs
+  profile:
+    type: hostPath
+    hostPath: /mnt/{{ .Release.Name }}/profile
+  video:
+    type: hostPath
+    hostPath: /mnt/{{ .Release.Name }}/video
+  additionalLibraries:
+    - hostPath: /mnt/{{ .Release.Name }}/additionalLibrary1
+    - hostPath: /mnt/{{ .Release.Name }}/additionalLibrary2
+  pgData:
+    type: hostPath
+    hostPath: /mnt/{{ .Release.Name }}/pgData
+  pgBackup:
+    type: hostPath
+    hostPath: /mnt/{{ .Release.Name }}/pgBackup

--- a/library/ix-dev/community/immich/questions.yaml
+++ b/library/ix-dev/community/immich/questions.yaml
@@ -291,6 +291,28 @@ questions:
                   show_if: [["type", "=", "hostPath"]]
                   immutable: true
                   required: true
+        - variable: additionalLibraries
+          label: Additional Libraries
+          description: |
+            Additional libraries for Immich.</br>
+            Internal mountPath will be the same as your hostPath</br>
+            https://immich.app/docs/features/read-only-gallery
+          schema:
+            type: list
+            default: []
+            items:
+              - variable: storageEntry
+                label: Storage Entry
+                schema:
+                  type: dict
+                  attrs:
+                    - variable: hostPath
+                      label: Host Path
+                      description: The host path to use for storage.
+                      schema:
+                        type: hostpath
+                        show_if: [["type", "=", "hostPath"]]
+                        required: true
         - variable: pgData
           label: Immich Postgres Data Storage
           description: The path to store Immich Postgres Data.

--- a/library/ix-dev/community/immich/questions.yaml
+++ b/library/ix-dev/community/immich/questions.yaml
@@ -311,7 +311,6 @@ questions:
                       description: The host path to use for storage.
                       schema:
                         type: hostpath
-                        show_if: [["type", "=", "hostPath"]]
                         required: true
         - variable: pgData
           label: Immich Postgres Data Storage

--- a/library/ix-dev/community/immich/templates/_persistence.tpl
+++ b/library/ix-dev/community/immich/templates/_persistence.tpl
@@ -61,7 +61,20 @@ persistence:
       microservices:
         microservices:
           mountPath: /usr/src/app/upload/encoded-video
-
+  {{- range $idx, $storage := .Values.immichStorage.additionalLibraries }}
+  {{ printf "immich-%v" (int $idx) }}:
+    enabled: true
+    type: hostPath
+    hostPath: {{ $storage.hostPath | default "" }}
+    # Host path and mount path MUST be the same
+    targetSelector:
+      server:
+        server:
+          mountPath: {{ $storage.hostPath }}
+      microservices:
+        microservices:
+          mountPath: {{ $storage.hostPath }}
+  {{- end }}
   {{/* Caches */}}
   microcache:
     enabled: true

--- a/library/ix-dev/community/immich/values.yaml
+++ b/library/ix-dev/community/immich/values.yaml
@@ -62,6 +62,7 @@ immichStorage:
   video:
     type: ixVolume
     datasetName: video
+  additionalLibraries: []
   pgData:
     type: ixVolume
     datasetName: pgData


### PR DESCRIPTION
Only hostPath type is used here, as the hostPath and mountPath must be exactly the same.

https://immich.app/docs/features/read-only-gallery