### PR TITLE
Bump immich app version to 1.66.1

### DIFF
--- a/library/ix-dev/community/immich/Chart.yaml
+++ b/library/ix-dev/community/immich/Chart.yaml
@@ -3,9 +3,9 @@ description: Immich
 annotations:
   title: Immich
 type: application
-version: 1.0.0
+version: 1.0.1
 apiVersion: v2
-appVersion: '1.61.1'
+appVersion: '1.66.1'
 kubeVersion: '>=1.16.0-0'
 maintainers:
   - name: truenas


### PR DESCRIPTION
Thanks for adding immich! But the app version is inconsistent with the docker image tag so I'm trying to fix that in this pull request.