### PR TITLE
NAS-122681 / 23.10 / Handle longer ints in few places that might have one

### DIFF
--- a/library/common-test/tests/container/envFixed_test.yaml
+++ b/library/common-test/tests/container/envFixed_test.yaml
@@ -376,7 +376,65 @@ tests:
               - name: S6_READ_ONLY_ROOT
                 value: "1"
 
-  # Failures
+  - it: should create the correct fixed envs with large int values
+    set:
+      image: *image
+      workload:
+        workload-name:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec:
+            securityContext:
+              fsGroup: 100000514
+            containers:
+              container-name1:
+                enabled: true
+                primary: true
+                imageSelector: image
+                probes: *probes
+                fixedEnv:
+                  PUID: 200000514
+                securityContext:
+                  runAsUser: 0
+                  runAsGroup: 0
+                  runAsNonRoot: false
+    asserts:
+      - documentIndex: &deploymentDoc 0
+        isKind:
+          of: Deployment
+      - documentIndex: *deploymentDoc
+        isAPIVersion:
+          of: apps/v1
+      - documentIndex: *deploymentDoc
+        isSubset:
+          path: spec.template.spec.containers[0]
+          content:
+            env:
+              - name: TZ
+                value: UTC
+              - name: UMASK
+                value: "002"
+              - name: UMASK_SET
+                value: "002"
+              - name: NVIDIA_VISIBLE_DEVICES
+                value: "void"
+              - name: PUID
+                value: "200000514"
+              - name: USER_ID
+                value: "200000514"
+              - name: UID
+                value: "200000514"
+              - name: PGID
+                value: "100000514"
+              - name: GROUP_ID
+                value: "100000514"
+              - name: GID
+                value: "100000514"
+              - name: S6_READ_ONLY_ROOT
+                value: "1"
+
+  # # Failures
   - it: it should fail with NVIDIA_CAPS having invalid values
     set:
       image: *image

--- a/library/common-test/tests/container/envList_test.yaml
+++ b/library/common-test/tests/container/envList_test.yaml
@@ -35,6 +35,8 @@ tests:
                     value: "{{ .Values.some_other_value }}"
                   - name: env3
                     value: ""
+                  - name: env4
+                    value: 100000514
     asserts:
       - documentIndex: &deploymentDoc 0
         isKind:
@@ -60,6 +62,12 @@ tests:
           content:
             name: env3
             value: ""
+      - documentIndex: *deploymentDoc
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: env4
+            value: "100000514"
 
   # Failures
   - it: it should fail with empty name

--- a/library/common-test/tests/container/envList_test.yaml
+++ b/library/common-test/tests/container/envList_test.yaml
@@ -37,6 +37,8 @@ tests:
                     value: ""
                   - name: env4
                     value: 100000514
+                  - name: env5
+                    value: 100text000514
     asserts:
       - documentIndex: &deploymentDoc 0
         isKind:
@@ -68,6 +70,12 @@ tests:
           content:
             name: env4
             value: "100000514"
+      - documentIndex: *deploymentDoc
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: env5
+            value: "100text000514"
 
   # Failures
   - it: it should fail with empty name

--- a/library/common-test/tests/container/envList_test.yaml
+++ b/library/common-test/tests/container/envList_test.yaml
@@ -38,7 +38,11 @@ tests:
                   - name: env4
                     value: 100000514
                   - name: env5
+                    value: "100000514"
+                  - name: env6
                     value: 100text000514
+                  - name: env7
+                    value: "100.400"
     asserts:
       - documentIndex: &deploymentDoc 0
         isKind:
@@ -75,7 +79,19 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: env5
+            value: "100000514"
+      - documentIndex: *deploymentDoc
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: env6
             value: "100text000514"
+      - documentIndex: *deploymentDoc
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: env7
+            value: "100.400"
 
   # Failures
   - it: it should fail with empty name

--- a/library/common-test/tests/container/env_test.yaml
+++ b/library/common-test/tests/container/env_test.yaml
@@ -66,6 +66,7 @@ tests:
                       fieldPath: metadata.name
                   VAR8: ""
                   VAR9: false
+                  VAR10: 100000514
     asserts:
       - documentIndex: &deploymentDoc 2
         isKind:
@@ -141,6 +142,12 @@ tests:
           content:
             name: VAR9
             value: "false"
+      - documentIndex: *deploymentDoc
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VAR10
+            value: "100000514"
 
   # Failures
   - it: it should fail invalid ref

--- a/library/common-test/tests/container/env_test.yaml
+++ b/library/common-test/tests/container/env_test.yaml
@@ -67,6 +67,7 @@ tests:
                   VAR8: ""
                   VAR9: false
                   VAR10: 100000514
+                  VAR11: 1000text00514
     asserts:
       - documentIndex: &deploymentDoc 2
         isKind:
@@ -148,6 +149,12 @@ tests:
           content:
             name: VAR10
             value: "100000514"
+      - documentIndex: *deploymentDoc
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VAR11
+            value: "1000text00514"
 
   # Failures
   - it: it should fail invalid ref

--- a/library/common-test/tests/container/env_test.yaml
+++ b/library/common-test/tests/container/env_test.yaml
@@ -66,8 +66,10 @@ tests:
                       fieldPath: metadata.name
                   VAR8: ""
                   VAR9: false
-                  VAR10: 100000514
-                  VAR11: 1000text00514
+                  VAR10: "100000514"
+                  VAR11: 100000514
+                  VAR12: 1000text00514
+                  VAR13: "100.40"
     asserts:
       - documentIndex: &deploymentDoc 2
         isKind:
@@ -154,7 +156,19 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: VAR11
+            value: "100000514"
+      - documentIndex: *deploymentDoc
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VAR12
             value: "1000text00514"
+      - documentIndex: *deploymentDoc
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VAR13
+            value: "100.40"
 
   # Failures
   - it: it should fail invalid ref

--- a/library/common-test/tests/pod/securityContext.yaml
+++ b/library/common-test/tests/pod/securityContext.yaml
@@ -134,6 +134,35 @@ tests:
               - name: some_other_name
                 value: "some_different_value"
 
+  - it: should pass with fsGroup and supplementalGroups with long int
+    set:
+      workload:
+        workload-name1:
+          enabled: true
+          primary: true
+          type: Deployment
+          podSpec:
+            securityContext:
+              fsGroup: 100000514
+              fsGroupChangePolicy: Always
+              supplementalGroups:
+                - 1002
+                - 100000514
+    asserts:
+      - documentIndex: *deploymentDoc
+        isKind:
+          of: Deployment
+      - documentIndex: *deploymentDoc
+        equal:
+          path: spec.template.spec.securityContext
+          value:
+            fsGroup: 100000514
+            fsGroupChangePolicy: Always
+            supplementalGroups:
+              - 1002
+              - 100000514
+            sysctls: []
+
   - it: should pass with sysctls automatically appended based on services
     set:
       some_sysctl_name: some_name

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A library chart for iX Official Catalog
 type: library
-version: 1.0.11
+version: 1.0.12
 appVersion: v1
 annotations:
   title: Common Library Chart

--- a/library/common/templates/helpers/_makeIntOrNoop.tpl
+++ b/library/common/templates/helpers/_makeIntOrNoop.tpl
@@ -2,7 +2,7 @@
   {{- $value := . -}}
 
   {{/* Anything with numbers, except those that start with 0. eg UMASK */}}
-  {{- if (mustRegexMatch "[1-9][0-9]+" (toString $value)) -}}
+  {{- if (mustRegexMatch "^[1-9][0-9]+$" (toString $value)) -}}
     {{- $value | int -}}
   {{- else -}}
     {{- $value -}}

--- a/library/common/templates/helpers/_makeIntOrNoop.tpl
+++ b/library/common/templates/helpers/_makeIntOrNoop.tpl
@@ -1,0 +1,10 @@
+{{- define "ix.v1.common.helper.makeIntOrNoop" -}}
+  {{- $value := . -}}
+
+  {{/* Anything with numbers, except those that start with 0. eg UMASK */}}
+  {{- if (mustRegexMatch "[1-9][0-9]+" (toString $value)) -}}
+    {{- $value | int -}}
+  {{- else -}}
+    {{- $value -}}
+  {{- end -}}
+{{- end -}}

--- a/library/common/templates/helpers/_makeIntOrNoop.tpl
+++ b/library/common/templates/helpers/_makeIntOrNoop.tpl
@@ -1,8 +1,9 @@
 {{- define "ix.v1.common.helper.makeIntOrNoop" -}}
   {{- $value := . -}}
 
-  {{/* Anything with numbers, except those that start with 0. eg UMASK */}}
-  {{- if (mustRegexMatch "^[1-9][0-9]+$" (toString $value)) -}}
+  {{/* Match scientific notation numbers */}}
+  # FIXME: needs better regex
+  {{- if (mustRegexMatch "^[1-9][0-9]+e\\+[0-9]+$" (toString $value)) -}}
     {{- $value | int -}}
   {{- else -}}
     {{- $value -}}

--- a/library/common/templates/helpers/_makeIntOrNoop.tpl
+++ b/library/common/templates/helpers/_makeIntOrNoop.tpl
@@ -1,9 +1,21 @@
 {{- define "ix.v1.common.helper.makeIntOrNoop" -}}
   {{- $value := . -}}
 
-  {{/* Match scientific notation numbers */}}
-  # FIXME: needs better regex
-  {{- if (mustRegexMatch "^[1-9][0-9]+e\\+[0-9]+$" (toString $value)) -}}
+  {{/*
+      Ints in Helm can be either int, int64 or float64.
+
+      Values that start with zero should not be converted
+      to int again as this will strip leading zeros.
+
+      Numbers converted to E notation by Helm will
+      always contain the "e" character. So we only
+      convert those.
+  */}}
+  {{- if and
+      (mustHas (kindOf $value) (list "int" "int64" "float64"))
+      (not (hasPrefix "0" ($value | toString)))
+      (contains "e" ($value | toString | lower))
+  -}}
     {{- $value | int -}}
   {{- else -}}
     {{- $value -}}

--- a/library/common/templates/lib/container/_env.tpl
+++ b/library/common/templates/lib/container/_env.tpl
@@ -15,9 +15,12 @@ objectData: The object data to be used to render the container.
       {{- $value := "" -}}
       {{/* Only tpl valid values, there are cases that empty values after merges can be "<nil>" */}}
       {{- if not (kindIs "invalid" $v) -}}
-        {{- $value = tpl (toString $v) $rootCtx -}}
+        {{- $value = $v -}}
+        {{- if kindIs "string" $v -}}
+          {{- $value = tpl $v $rootCtx -}}
+        {{- end -}}
       {{- end }}
-  value: {{ $value | quote }}
+  value: {{ include "ix.v1.common.helper.makeIntOrNoop" $value | quote }}
     {{- else if kindIs "map" $v }}
   valueFrom:
       {{- $refs := (list "configMapKeyRef" "secretKeyRef" "fieldRef") -}}

--- a/library/common/templates/lib/container/_envList.tpl
+++ b/library/common/templates/lib/container/_envList.tpl
@@ -12,8 +12,12 @@ objectData: The object data to be used to render the container.
     {{- if not $env.name -}}
       {{- fail "Container - Expected non-empty <envList.name>" -}}
     {{- end -}} {{/* Empty value is valid */}}
-    {{- include "ix.v1.common.helper.container.envDupeCheck" (dict "rootCtx" $rootCtx "objectData" $objectData "source" "envList" "key" $env.name) }}
+    {{- include "ix.v1.common.helper.container.envDupeCheck" (dict "rootCtx" $rootCtx "objectData" $objectData "source" "envList" "key" $env.name) -}}
+    {{- $value := $env.value -}}
+    {{- if kindIs "string" $env.value -}}
+      {{- $value = tpl $env.value $rootCtx -}}
+    {{- end }}
 - name: {{ $env.name | quote }}
-  value: {{ tpl (toString $env.value) $rootCtx | quote }}
+  value: {{ include "ix.v1.common.helper.makeIntOrNoop" $value | quote }}
   {{- end -}}
 {{- end -}}

--- a/library/common/templates/lib/container/_fixedEnv.tpl
+++ b/library/common/templates/lib/container/_fixedEnv.tpl
@@ -69,6 +69,6 @@ objectData: The object data to be used to render the container.
   {{- range $env := $fixed -}}
     {{- include "ix.v1.common.helper.container.envDupeCheck" (dict "rootCtx" $rootCtx "objectData" $objectData "source" "fixedEnv" "key" $env.k) }}
 - name: {{ $env.k | quote }}
-  value: {{ $env.v | quote }}
+  value: {{ (include "ix.v1.common.helper.makeIntOrNoop" $env.v) | quote }}
   {{- end -}}
 {{- end -}}

--- a/library/common/templates/lib/pod/_podSecurityContext.tpl
+++ b/library/common/templates/lib/pod/_podSecurityContext.tpl
@@ -64,12 +64,12 @@ objectData: The object data to be used to render the Pod.
   {{- if not (mustHas $secContext.fsGroupChangePolicy $policies) -}}
     {{- fail (printf "Pod - Expected <fsGroupChangePolicy> to be one of [%s], but got [%s]" (join ", " $policies) $secContext.fsGroupChangePolicy) -}}
   {{- end }}
-fsGroup: {{ $secContext.fsGroup }}
+fsGroup: {{ include "ix.v1.common.helper.makeIntOrNoop" $secContext.fsGroup }}
 fsGroupChangePolicy: {{ $secContext.fsGroupChangePolicy }}
   {{- with $secContext.supplementalGroups }}
 supplementalGroups:
     {{- range . }}
-  - {{ . }}
+  - {{ include "ix.v1.common.helper.makeIntOrNoop" . }}
     {{- end -}}
   {{- else }}
 supplementalGroups: []


### PR DESCRIPTION
Helm converts longer ints into scientific notation when **printing** them. 

This PR adds a function that detects such numbers and converts them back to int. 
This PR also uses this function in a few places that are more common to see such numbers and adds tests for those cases.