### PR TITLE
NAS-122987 / 23.10 / change default nextcloud cron schedule

### DIFF
--- a/library/ix-dev/charts/nextcloud/Chart.yaml
+++ b/library/ix-dev/charts/nextcloud/Chart.yaml
@@ -4,7 +4,7 @@ description: A file sharing server that puts the control and security of your ow
 annotations:
   title: Nextcloud
 type: application
-version: 1.6.33
+version: 1.6.34
 apiVersion: v2
 appVersion: 27.0.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/nextcloud/questions.yaml
+++ b/library/ix-dev/charts/nextcloud/questions.yaml
@@ -135,7 +135,7 @@ questions:
                 label: Schedule
                 schema:
                   type: string
-                  default: "1 */24 * * *"
+                  default: "*/5 * * * *"
                   empty: false
 
   # Update strategy

--- a/library/ix-dev/charts/nextcloud/questions.yaml
+++ b/library/ix-dev/charts/nextcloud/questions.yaml
@@ -135,7 +135,7 @@ questions:
                 label: Schedule
                 schema:
                   type: string
-                  default: "*/5 * * * *"
+                  default: "*/15 * * * *"
                   empty: false
 
   # Update strategy


### PR DESCRIPTION
Changes default Nextcloud Cron Schedule to "every 15 min"

It's better to run it frequently instead of letting background jobs (jobs like housekeeping and others) to queue up.

> Note that the cron.php does not include things like thumbnail generation. So it's usually a very light/fast operation

---

Fixes #1306

