### PR TITLE
NAS-122965 / 23.10 / fix default value on certificates

### DIFF
--- a/library/ix-dev/charts/elastic-search/Chart.yaml
+++ b/library/ix-dev/charts/elastic-search/Chart.yaml
@@ -3,7 +3,7 @@ description: Elasticsearch is the distributed, RESTful search and analytics engi
 annotations:
   title: Elastic Search
 type: application
-version: 1.0.15
+version: 1.0.16
 apiVersion: v2
 appVersion: 8.8.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/elastic-search/values.yaml
+++ b/library/ix-dev/charts/elastic-search/values.yaml
@@ -22,7 +22,7 @@ esRunAs:
 esNetwork:
   httpPort: 30003
   hostNetwork: false
-  certificateID: ''
+  certificateID: null
 
 esStorage:
   data:

--- a/library/ix-dev/community/filebrowser/Chart.yaml
+++ b/library/ix-dev/community/filebrowser/Chart.yaml
@@ -3,7 +3,7 @@ description: File Browser provides a file managing interface within a specified 
 annotations:
   title: File Browser
 type: application
-version: 1.0.4
+version: 1.0.5
 apiVersion: v2
 appVersion: 'v2.23.0'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/filebrowser/values.yaml
+++ b/library/ix-dev/community/filebrowser/values.yaml
@@ -13,7 +13,7 @@ filebrowserConfig:
 
 filebrowserNetwork:
   webPort: 30044
-  certificateID: 0
+  certificateID: null
   hostNetwork: false
 
 filebrowserRunAs:

--- a/library/ix-dev/community/gitea/Chart.yaml
+++ b/library/ix-dev/community/gitea/Chart.yaml
@@ -3,7 +3,7 @@ description: Gitea - Git with a cup of tea
 annotations:
   title: Gitea
 type: application
-version: 1.0.12
+version: 1.0.13
 apiVersion: v2
 appVersion: '1.19.0'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/gitea/values.yaml
+++ b/library/ix-dev/community/gitea/values.yaml
@@ -14,7 +14,7 @@ giteaConfig:
 giteaNetwork:
   webPort: 30008
   sshPort: 30009
-  certificateID: ""
+  certificateID: null
   rootURL: ""
   hostNetwork: false
 

--- a/library/ix-dev/community/grafana/Chart.yaml
+++ b/library/ix-dev/community/grafana/Chart.yaml
@@ -4,7 +4,7 @@ description: Grafana is the open source analytics & monitoring solution for ever
 annotations:
   title: Grafana
 type: application
-version: 1.0.7
+version: 1.0.8
 apiVersion: v2
 appVersion: 10.0.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/grafana/values.yaml
+++ b/library/ix-dev/community/grafana/values.yaml
@@ -15,7 +15,7 @@ grafanaConfig:
 grafanaNetwork:
   hostNetwork: false
   webPort: 30037
-  certificateID: 0
+  certificateID: null
   rootURL: ''
 
 grafanaRunAs:

--- a/library/ix-dev/community/jenkins/Chart.yaml
+++ b/library/ix-dev/community/jenkins/Chart.yaml
@@ -3,7 +3,7 @@ description: Jenkins is a leading open source automation server,
 annotations:
   title: Jenkins
 type: application
-version: 1.0.6
+version: 1.0.7
 apiVersion: v2
 appVersion: 2.401.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/jenkins/questions.yaml
+++ b/library/ix-dev/community/jenkins/questions.yaml
@@ -126,6 +126,7 @@ questions:
           description: The certificate to use for HTTPS.
           schema:
             type: int
+            "null": true
             $ref:
               - "definitions/certificate"
         - variable: agent

--- a/library/ix-dev/community/jenkins/values.yaml
+++ b/library/ix-dev/community/jenkins/values.yaml
@@ -15,7 +15,7 @@ jenkinsConfig:
 jenkinsNetwork:
   webPort: 30036
   https: false
-  certificateID: 0
+  certificateID: null
   agent: false
   agentPort: 50000
   hostNetwork: false

--- a/library/ix-dev/community/mineos/Chart.yaml
+++ b/library/ix-dev/community/mineos/Chart.yaml
@@ -3,7 +3,7 @@ description: MineOS is a server front-end to ease managing Minecraft administrat
 annotations:
   title: MineOS
 type: application
-version: 1.0.6
+version: 1.0.7
 apiVersion: v2
 appVersion: 'latest'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/mineos/migrations/migrate
+++ b/library/ix-dev/community/mineos/migrations/migrate
@@ -1,0 +1,20 @@
+#!/usr/bin/python3
+import json
+import os
+import sys
+
+
+def migrate(values):
+    if values.get('mineosNetwork', {}).get('certificateID', {}) == 0:
+        values['mineosNetwork']['certificateID'] = None
+
+    return values
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        exit(1)
+
+    if os.path.exists(sys.argv[1]):
+        with open(sys.argv[1], 'r') as f:
+            print(json.dumps(migrate(json.loads(f.read()))))

--- a/library/ix-dev/community/mineos/values.yaml
+++ b/library/ix-dev/community/mineos/values.yaml
@@ -21,7 +21,7 @@ mineosNetwork:
   mineosPortRangeStart: 30016
   mineosPortRangeEnd: 30017
   useHTTPS: false
-  certificateID: 0
+  certificateID: null
 mineosStorage:
   data:
     type: ixVolume

--- a/library/ix-dev/community/mumble/Chart.yaml
+++ b/library/ix-dev/community/mumble/Chart.yaml
@@ -3,7 +3,7 @@ description: Mumble is a free, open source, low latency, high quality voice chat
 annotations:
   title: Mumble
 type: application
-version: 1.0.8
+version: 1.0.9
 apiVersion: v2
 appVersion: 'v1.4.230'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/mumble/values.yaml
+++ b/library/ix-dev/community/mumble/values.yaml
@@ -21,7 +21,7 @@ mumbleConfig:
 mumbleNetwork:
   serverPort: 30018
   icePort: 30019
-  certificateID: 0
+  certificateID: null
 mumbleStorage:
   data:
     type: ixVolume

--- a/library/ix-dev/community/vaultwarden/Chart.yaml
+++ b/library/ix-dev/community/vaultwarden/Chart.yaml
@@ -3,7 +3,7 @@ description: Alternative implementation of the Bitwarden server API written in R
 annotations:
   title: Vaultwarden
 type: application
-version: 1.0.18
+version: 1.0.19
 apiVersion: v2
 appVersion: 1.29.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/vaultwarden/values.yaml
+++ b/library/ix-dev/community/vaultwarden/values.yaml
@@ -17,7 +17,7 @@ vaultwardenNetwork:
   wsEnabled: true
   wsPort: 30033
   hostNetwork: false
-  certificateID: 0
+  certificateID: null
   domain: ''
 
 vaultwardenRunAs:

--- a/library/ix-dev/community/webdav/Chart.yaml
+++ b/library/ix-dev/community/webdav/Chart.yaml
@@ -3,7 +3,7 @@ description: WebDAV is a set of extensions to the HTTP protocol which allows use
 annotations:
   title: WebDAV
 type: application
-version: 1.0.7
+version: 1.0.8
 apiVersion: v2
 appVersion: '1.1.3.2982'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/webdav/migrations/migrate
+++ b/library/ix-dev/community/webdav/migrations/migrate
@@ -1,0 +1,20 @@
+#!/usr/bin/python3
+import json
+import os
+import sys
+
+
+def migrate(values):
+    if values.get('webdavNetwork', {}).get('certificateID', {}) == 0:
+        values['webdavNetwork']['certificateID'] = None
+
+    return values
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        exit(1)
+
+    if os.path.exists(sys.argv[1]):
+        with open(sys.argv[1], 'r') as f:
+            print(json.dumps(migrate(json.loads(f.read()))))

--- a/library/ix-dev/community/webdav/values.yaml
+++ b/library/ix-dev/community/webdav/values.yaml
@@ -19,7 +19,7 @@ webdavNetwork:
   httpPort: 30034
   https: false
   httpsPort: 30035
-  certificateID: 0
+  certificateID: null
 webdavRunAs:
   user: 568
   group: 568

--- a/library/ix-dev/enterprise/minio/Chart.yaml
+++ b/library/ix-dev/enterprise/minio/Chart.yaml
@@ -3,7 +3,7 @@ description: High Performance, Kubernetes Native Object Storage
 annotations:
   title: MinIO
 type: application
-version: 1.0.17
+version: 1.0.18
 apiVersion: v2
 appVersion: '2023-03-24'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/enterprise/minio/values.yaml
+++ b/library/ix-dev/enterprise/minio/values.yaml
@@ -24,7 +24,7 @@ minioRunAs:
 minioNetwork:
   apiPort: 30000
   webPort: 30001
-  certificateID: 0
+  certificateID: null
   hostNetwork: true
   serverUrl: ''
   consoleUrl: ''

--- a/library/ix-dev/enterprise/syncthing/Chart.yaml
+++ b/library/ix-dev/enterprise/syncthing/Chart.yaml
@@ -3,7 +3,7 @@ description: Syncthing is a continuous file synchronization program.
 annotations:
   title: Syncthing
 type: application
-version: 1.0.7
+version: 1.0.8
 apiVersion: v2
 appVersion: '1.23.3'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/enterprise/syncthing/values.yaml
+++ b/library/ix-dev/enterprise/syncthing/values.yaml
@@ -24,7 +24,7 @@ syncthingID:
 
 syncthingNetwork:
   webPort: 30000
-  certificateID: 0
+  certificateID: null
   hostNetwork: true
   # Only used if hostNetwork is false
   localDiscoveryPort: 21027


### PR DESCRIPTION
- Sets certificate default value to `null`
- Makes sure `"null": true` is set on the schema
- Applies migrations on apps that the certificate was not shown at all times.
  (On apps that certificate is shown at all times, the correct default value is set by the UI at install time)