### PR TITLE
NAS-122338 / 23.10 / Add port definitions ref

### DIFF
--- a/features_capability.json
+++ b/features_capability.json
@@ -35,6 +35,10 @@
     "stable": {"min": "21.04-ALPHA"},
     "nightlies": {"min": "21.02-MASTER"}
   },
+  "definitions/port": {
+    "stable": {"min": "23.10-BETA.1"},
+    "nightlies": {"min": "23.10-MASTER"}
+  },
   "validations/containerImage": {
     "stable": {"min": "21.06-BETA"},
     "nightlies": {"min": "21.04-MASTER"}


### PR DESCRIPTION
## Context

A `ref` is being added so questions in an app which consume ports and allow it to be user configurable have a way to show unused ports which can actually be used by the app.