### PR TITLE
NAS-122925 / 23.10 / increase nextcloud startup probe

### DIFF
--- a/library/ix-dev/charts/nextcloud/Chart.yaml
+++ b/library/ix-dev/charts/nextcloud/Chart.yaml
@@ -4,7 +4,7 @@ description: A file sharing server that puts the control and security of your ow
 annotations:
   title: Nextcloud
 type: application
-version: 1.6.34
+version: 1.6.35
 apiVersion: v2
 appVersion: 27.0.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/nextcloud/templates/deployment.yaml
+++ b/library/ix-dev/charts/nextcloud/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec: {{ include "common.deployment.common_spec" . | nindent 2 }}
             httpHeaders:
             - name: Host
               value: localhost
-          initialDelaySeconds: 10
+          initialDelaySeconds: 30
           periodSeconds: 5
           timeoutSeconds: 2
           failureThreshold: 60
@@ -150,10 +150,10 @@ spec: {{ include "common.deployment.common_spec" . | nindent 2 }}
             - name: Host
               value: localhost
         {{ end }}
-          initialDelaySeconds: 10
-          periodSeconds: 10
-          timeoutSeconds: 5
-          failureThreshold: 5
+          initialDelaySeconds: 60
+          periodSeconds: 5
+          timeoutSeconds: 2
+          failureThreshold: 120
           successThreshold: 1
         volumeMounts:
         - name: nextcloud-data


### PR DESCRIPTION
Increases nextcloud startupProbe to **10m**, to give it some headroom on installation/upgrades.

It shouldn't take that much when apps are on SSD, 
but on systems without SSDs for apps, it sometimes needs the headroom.