### PR TITLE
NAS-123156 / 23.10 / Add some extra validation on minio

### DIFF
--- a/library/ix-dev/enterprise/minio/Chart.yaml
+++ b/library/ix-dev/enterprise/minio/Chart.yaml
@@ -3,7 +3,7 @@ description: High Performance, Kubernetes Native Object Storage
 annotations:
   title: MinIO
 type: application
-version: 1.0.19
+version: 1.0.20
 apiVersion: v2
 appVersion: '2023-03-24'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/enterprise/minio/questions.yaml
+++ b/library/ix-dev/enterprise/minio/questions.yaml
@@ -141,7 +141,7 @@ questions:
       For Multi Node Multi Drive (MNMD), the entry will look like this:</br>
       Example Entry - https://minio{1...3}.example.com:30000/data{1...4}</br></br>
       Note that each host must use the same port number and the same number of storage items.</br>
-      In both cases /data{1..4} is the directories to be used for MinIO.
+      In both cases /data{1...4} is the directories to be used for MinIO.
       You have to add additional storage for each data entry.
     schema:
       type: boolean

--- a/library/ix-dev/enterprise/minio/templates/_helpers.tpl
+++ b/library/ix-dev/enterprise/minio/templates/_helpers.tpl
@@ -39,7 +39,26 @@
   {{- end -}}
 
   {{- if and (ne (len .Values.minioStorage) 1) (not .Values.minioMultiMode) -}}
-    {{- fail "Expected Multi Mode to be enabled, when more than 1 storage items added" -}}
+    {{- fail "Expected Multi Mode to be enabled, when more than 1 storage mountPaths added" -}}
+  {{- end -}}
+
+  {{- range $item := .Values.minioMultiMode -}}
+    {{- if hasPrefix "/" $item -}}
+      {{- if or (contains "{" $item) (contains "}" $item) -}}
+        {{- if not (contains "..." $item) -}}
+          {{- fail "Expected Multi Mode Item to have 3 dots when its a path with expansion eg [/some_path{1...4}]" -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- $mountPaths := list -}}
+  {{- range $item := .Values.minioStorage -}}
+    {{- $mountPaths = mustAppend $mountPaths $item.mountPath -}}
+  {{- end -}}
+
+  {{- if not (deepEqual ($mountPaths) (uniq $mountPaths)) -}}
+    {{- fail (printf "Expected mountPaths to be unique, but got [%v]" (join ", " $mountPaths)) -}}
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Validates that mountPaths are unique.
Validates that when in multiMode an argument that starts with `/` and contains either `{` or `}`,it also contains `...` (3 dots).
As its a common mistake to confuse it with the bash's "range" `/data{1..4}` While minIO expects it to be in this format `/data{1...4}`