### PR TITLE
NAS-123186 / 23.10 / add db details in NOTES.txt

### DIFF
--- a/library/ix-dev/community/immich/Chart.yaml
+++ b/library/ix-dev/community/immich/Chart.yaml
@@ -3,7 +3,7 @@ description: Immich
 annotations:
   title: Immich
 type: application
-version: 1.0.7
+version: 1.0.8
 apiVersion: v2
 appVersion: 1.69.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/immich/templates/_configuration.tpl
+++ b/library/ix-dev/community/immich/templates/_configuration.tpl
@@ -10,6 +10,11 @@
     {{- $dbPass = ((index .data "POSTGRES_PASSWORD") | b64dec) -}}
   {{- end -}}
 
+  {{/* Temporary set dynamic db details on values,
+  so we can print them on the notes */}}
+  {{- $_ := set .Values "immichDbPass" $dbPass -}}
+  {{- $_ := set .Values "immichDbHost" $dbHost -}}
+
   {{- $redisHost := (printf "%s-redis" $fullname) -}}
 
   {{- $redisPass := randAlphaNum 32 -}}

--- a/library/ix-dev/community/immich/values.yaml
+++ b/library/ix-dev/community/immich/values.yaml
@@ -73,7 +73,7 @@ immichStorage:
 notes:
   custom: |
     ## Database
-    You can connect to the database using the PGAdmin App from the catalog
+    You can connect to the database using the pgAdmin App from the catalog
 
     <details>
       <summary>Database Details</summary>

--- a/library/ix-dev/community/immich/values.yaml
+++ b/library/ix-dev/community/immich/values.yaml
@@ -69,3 +69,21 @@ immichStorage:
   pgBackup:
     type: ixVolume
     datasetName: pgBackup
+
+notes:
+  custom: |
+    ## Database
+    You can connect to the database using the PGAdmin App from the catalog
+
+    <details>
+      <summary>Database Details</summary>
+
+      - Database: `immich`
+      - Username: `immich`
+      - Password: `{{ .Values.immichDbPass }}`
+      - Host:     `{{ .Values.immichDbHost }}.{{ .Release.Namespace }}.svc.cluster.local`
+      - Port:     `5432`
+
+    </details>
+    {{- $_ := unset .Values "immichDbPass" }}
+    {{- $_ := unset .Values "immichDbHost" }}

--- a/library/ix-dev/community/vaultwarden/Chart.yaml
+++ b/library/ix-dev/community/vaultwarden/Chart.yaml
@@ -3,7 +3,7 @@ description: Alternative implementation of the Bitwarden server API written in R
 annotations:
   title: Vaultwarden
 type: application
-version: 1.0.20
+version: 1.0.21
 apiVersion: v2
 appVersion: 1.29.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/vaultwarden/templates/_configuration.tpl
+++ b/library/ix-dev/community/vaultwarden/templates/_configuration.tpl
@@ -15,6 +15,11 @@
     {{- $dbPass = ((index .data "POSTGRES_PASSWORD") | b64dec) -}}
   {{- end -}}
 
+  {{/* Temporary set dynamic db details on values,
+  so we can print them on the notes */}}
+  {{- $_ := set .Values "vaultwardenDbPass" $dbPass -}}
+  {{- $_ := set .Values "vaultwardenDbHost" $dbHost -}}
+
   {{ $dbURL := (printf "postgres://%s:%s@%s:5432/%s?sslmode=disable" $dbUser $dbPass $dbHost $dbName) }}
 secret:
   postgres-creds:

--- a/library/ix-dev/community/vaultwarden/values.yaml
+++ b/library/ix-dev/community/vaultwarden/values.yaml
@@ -38,7 +38,7 @@ vaultwardenStorage:
 notes:
   custom: |
     ## Database
-    You can connect to the database using the PGAdmin App from the catalog
+    You can connect to the database using the pgAdmin App from the catalog
 
     <details>
       <summary>Database Details</summary>

--- a/library/ix-dev/community/vaultwarden/values.yaml
+++ b/library/ix-dev/community/vaultwarden/values.yaml
@@ -34,3 +34,21 @@ vaultwardenStorage:
   pgBackup:
     type: ixVolume
     datasetName: pgBackup
+
+notes:
+  custom: |
+    ## Database
+    You can connect to the database using the PGAdmin App from the catalog
+
+    <details>
+      <summary>Database Details</summary>
+
+      - Database: `vaultwarden`
+      - Username: `vaultwarden`
+      - Password: `{{ .Values.vaultwardenDbPass }}`
+      - Host:     `{{ .Values.vaultwardenDbHost }}.{{ .Release.Namespace }}.svc.cluster.local`
+      - Port:     `5432`
+
+    </details>
+    {{- $_ := unset .Values "vaultwardenDbPass" }}
+    {{- $_ := unset .Values "vaultwardenDbHost" }}


### PR DESCRIPTION
With the addition of PGAdmin, users can now connect to databases using the internal DNS of the cluster.
This PR adds the needed info in the NOTES.txt, which is also now displayed in the new Apps UI.

This will also allow users to do database exports or migrations if needed.

> This PR only adds the notes to the apps with PGSQL that are on the new common lib.
> A followup will come for the other apps.

Example markdown output:

---

NOTES:
# Welcome to TrueNAS SCALE
Thank you for installing Immich App.

## Database
You can connect to the database using the PGAdmin App from the catalog

<details>
  <summary>Database Details</summary>

  - Database: `immich`
  - Username: `immich`
  - Password: `AFXTEJF8OK6WbtNmUJpS8b8vUGqq86ZA`
  - Host:     `immich-postgres.ix-immich.svc.cluster.local`
  - Port:     `5432`

</details>

# Documentation
Documentation for this app can be found at https://www.truenas.com/docs.
# Bug reports
If you find a bug in this app, please file an issue at https://ixsystems.atlassian.net
