### PR TITLE
SABnzbd: Update catalog icon

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -1209,7 +1209,7 @@
                 "https://github.com/truenas/charts/tree/master/library/ix-dev/community/sabnzbd",
                 "https://github.com/Sabnzbd/Sabnzbd"
             ],
-            "icon_url": "https://avatars.githubusercontent.com/u/960698"
+            "icon_url": "https://raw.githubusercontent.com/sabnzbd/sabnzbd/develop/icons/logo-arrow.svg"
         },
         "grafana": {
             "app_readme": "<h1>Grafana</h1>\n<p><a href=\"https://grafana.com/\">Grafana</a> is the open source analytics &amp; monitoring solution for every database.</p>\n<blockquote>\n<p>When application is installed, a container will be launched with <strong>root</strong> privileges.\nThis is required in order to apply the correct permissions to the <code>Grafana</code> directories.\nAfterward, the <code>Grafana</code> container will run as a <strong>non</strong>-root user (Default: <code>568</code>).\nAll mounted storage(s) will be <code>chown</code>ed only if the parent directory does not match the configured user.</p>\n</blockquote>\n<p>Additional configuration can be made by adding additional environment variables\nHere is the available <a href=\"https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/\">configuration documentation</a></p>\n<p>Use the following syntax:\n<code>GF_&lt;SECTION-NAME&gt;_&lt;KEY-NAME&gt;</code></p>\n<p>Example:\n<code>GF_SMTP_ENABLED</code></p>",

--- a/catalog.json
+++ b/catalog.json
@@ -1209,7 +1209,7 @@
                 "https://github.com/truenas/charts/tree/master/library/ix-dev/community/sabnzbd",
                 "https://github.com/Sabnzbd/Sabnzbd"
             ],
-            "icon_url": "https://raw.githubusercontent.com/sabnzbd/sabnzbd/develop/icons/logo-arrow.svg"
+            "icon_url": "https://avatars.githubusercontent.com/u/960698"
         },
         "grafana": {
             "app_readme": "<h1>Grafana</h1>\n<p><a href=\"https://grafana.com/\">Grafana</a> is the open source analytics &amp; monitoring solution for every database.</p>\n<blockquote>\n<p>When application is installed, a container will be launched with <strong>root</strong> privileges.\nThis is required in order to apply the correct permissions to the <code>Grafana</code> directories.\nAfterward, the <code>Grafana</code> container will run as a <strong>non</strong>-root user (Default: <code>568</code>).\nAll mounted storage(s) will be <code>chown</code>ed only if the parent directory does not match the configured user.</p>\n</blockquote>\n<p>Additional configuration can be made by adding additional environment variables\nHere is the available <a href=\"https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/\">configuration documentation</a></p>\n<p>Use the following syntax:\n<code>GF_&lt;SECTION-NAME&gt;_&lt;KEY-NAME&gt;</code></p>\n<p>Example:\n<code>GF_SMTP_ENABLED</code></p>",

--- a/library/ix-dev/community/sabnzbd/Chart.yaml
+++ b/library/ix-dev/community/sabnzbd/Chart.yaml
@@ -3,7 +3,7 @@ description: SABnzbd is an Open Source Binary Newsreader written in Python.
 annotations:
   title: SABnzbd
 type: application
-version: 1.0.0
+version: 1.0.1
 apiVersion: v2
 appVersion: 4.0.3
 kubeVersion: '>=1.16.0-0'
@@ -16,7 +16,7 @@ dependencies:
     repository: file://../../../common
     version: 1.0.12
 home: https://sabnzbd.org/
-icon: https://avatars.githubusercontent.com/u/960698
+icon: https://raw.githubusercontent.com/sabnzbd/sabnzbd/develop/icons/logo-arrow.svg
 sources:
   - https://github.com/onedr0p/containers/tree/main/apps/sabnzbd
   - https://github.com/truenas/charts/tree/master/library/ix-dev/community/sabnzbd

--- a/library/ix-dev/community/sabnzbd/item.yaml
+++ b/library/ix-dev/community/sabnzbd/item.yaml
@@ -1,4 +1,4 @@
-icon_url: https://avatars.githubusercontent.com/u/960698
+icon_url: https://raw.githubusercontent.com/sabnzbd/sabnzbd/develop/icons/logo-arrow.svg
 categories:
   - media
 screenshots:


### PR DESCRIPTION
Currently, the SABnzbd chart has a non-transparent logo:
![Screenshot 2023-07-24 at 20 17 18](https://github.com/truenas/charts/assets/1167401/e01ca381-fd89-43db-b559-a18b75f53802)

This PR fixes that by changing the logo to the official SVG. [Source](https://github.com/sabnzbd/sabnzbd/blob/develop/icons/logo-arrow.svg).