### PR TITLE
Immich: fix misconfigured machinelearningPort

### DIFF
--- a/library/ix-dev/community/immich/Chart.yaml
+++ b/library/ix-dev/community/immich/Chart.yaml
@@ -3,7 +3,7 @@ description: Immich
 annotations:
   title: Immich
 type: application
-version: 1.0.7
+version: 1.0.8
 apiVersion: v2
 appVersion: 1.69.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/immich/templates/_configuration.tpl
+++ b/library/ix-dev/community/immich/templates/_configuration.tpl
@@ -26,7 +26,7 @@
 
   {{- $mlURL := "false" -}}
   {{- if .Values.immichConfig.enableML -}}
-    {{- $mlURL = printf "http://%v-machinelearning:%v" $fullname .Values.immichNetwork.microservicesPort -}}
+    {{- $mlURL = printf "http://%v-machinelearning:%v" $fullname .Values.immichNetwork.machinelearningPort -}}
   {{- end }}
 
 secret:


### PR DESCRIPTION
Hi TrueNAS team !

I found out that there was a misconfiguration between the microservices pod and the machinelearning pod.

The error was
```
2023-07-24 21:39:35.008278+00:002023-07-24T21:39:35.008278895Z
2023-07-24 21:39:36.031186+00:00[Nest] 8  - 07/24/2023, 5:39:36 PM   ERROR [JobService] Unable to run job handler: Error: connect ECONNREFUSED 172.17.39.233:32003
2023-07-24 21:39:36.031214+00:00[Nest] 8  - 07/24/2023, 5:39:36 PM   ERROR [JobService] Error: connect ECONNREFUSED 172.17.39.233:32003
2023-07-24 21:39:36.031220+00:00at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1494:16)
2023-07-24 21:39:36.031225+00:00[Nest] 8  - 07/24/2023, 5:39:36 PM   ERROR [JobService] Object:
2023-07-24 21:39:36.031229+00:00{
2023-07-24 21:39:36.031232+00:00"id": "7c8f9a80-ccb0-4712-a04b-4f157f20c9b2"
2023-07-24 21:39:36.031235+00:00}
```