### PR TITLE
NAS-123198 / 23.10 / bump minio and fix upgrade strategy

### DIFF
--- a/library/ix-dev/charts/minio/Chart.yaml
+++ b/library/ix-dev/charts/minio/Chart.yaml
@@ -3,7 +3,7 @@ description: High Performance, Kubernetes Native Object Storage
 annotations:
   title: MinIO
 type: application
-version: 1.7.16
+version: 1.7.17
 apiVersion: v2
 appVersion: '2023-03-13'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/minio/upgrade_info.json
+++ b/library/ix-dev/charts/minio/upgrade_info.json
@@ -1,1 +1,1 @@
-{"filename":  "ix_values.yaml", "keys": ["image"], "test_filename": "test_values.yaml"}
+{ "filename": "values.yaml", "keys": ["image"] }

--- a/library/ix-dev/charts/minio/upgrade_strategy
+++ b/library/ix-dev/charts/minio/upgrade_strategy
@@ -1,21 +1,56 @@
 #!/usr/bin/python3
 import json
+import re
 import sys
 
+from catalog_update.upgrade_strategy import semantic_versioning
 from catalog_update.upgrade_strategy import datetime_versioning
 
 
-def newer_mapping(image_tags):
-    key = list(image_tags.keys())[0]
-    tags = {t.strip('RELEASE.'): t for t in image_tags[key] if t.startswith('RELEASE.') and t.endswith('Z')}
-    version = datetime_versioning(list(tags), '%Y-%m-%dT%H-%M-%SZ')
-    if not version:
-        return {}
+ENUMS = {
+    'image': {
+        'RE_STABLE_VERSION': re.compile(r'RELEASE.\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}}Z'),
+        'STRIP_TEXT': 'RELEASE.',
+        'function': datetime_versioning,
+        'function_arg': '%Y-%m-%dT%H-%M-%SZ'
+    },
+    'logSearchImage': {
+        'RE_STABLE_VERSION': re.compile(r'v\d+\.\d+\.\d+'),
+        'STRIP_TEXT': 'v',
+        'function': semantic_versioning
+    },
+}
 
-    return {
-        'tags': {key: tags[version]},
-        'app_version': version.split('T')[0],
+
+def newer_mapping(image_tags):
+
+    output = {
+        "tags": {},
+        "app_version": ""
     }
+
+    for key in image_tags.keys():
+        STRIP_TEXT = ENUMS[key].get('STRIP_TEXT', None) if key in ENUMS else None
+        RE_STABLE_VERSION = ENUMS[key].get('RE_STABLE_VERSION', None) if key in ENUMS else None
+        VERSION_FUNCTION = ENUMS[key].get('function', None) if key in ENUMS else None
+
+        if (STRIP_TEXT is None) or (RE_STABLE_VERSION is None) or (VERSION_FUNCTION is None):
+            continue
+
+        tags = {t.strip(STRIP_TEXT): t for t in image_tags[key] if RE_STABLE_VERSION.fullmatch(t)}
+        if ENUMS[key].get('function_arg', None):
+            version = VERSION_FUNCTION(list(tags), ENUMS[key].get('function_arg'))
+        else:
+            version = VERSION_FUNCTION(list(tags))
+        if not version:
+            continue
+
+        if key == 'image':
+            output['app_version'] = version
+
+        output['tags'][key] = tags[version]
+
+    return output
 
 
 if __name__ == '__main__':

--- a/library/ix-dev/charts/minio/values.yaml
+++ b/library/ix-dev/charts/minio/values.yaml
@@ -1,7 +1,7 @@
 image:
   pullPolicy: IfNotPresent
   repository: minio/minio
-  tag: RELEASE.2023-03-13T19-46-17Z
+  tag: RELEASE.2023-07-21T21-12-44Z
 logSearchImage:
   pullPolicy: IfNotPresent
   repository: minio/operator


### PR DESCRIPTION
Fixes #1397

Currently logSearchImage will be kept disabled as it recently had a major version bump.