### PR TITLE
NAS-123235 / 23.10 / rename wg-easy deployment to allow smoother migration

### DIFF
--- a/library/ix-dev/charts/wg-easy/Chart.yaml
+++ b/library/ix-dev/charts/wg-easy/Chart.yaml
@@ -3,7 +3,7 @@ description: WG-Easy is the easiest way to install & manage WireGuard!
 annotations:
   title: WG Easy
 type: application
-version: 1.0.10
+version: 1.0.11
 apiVersion: v2
 appVersion: "7"
 kubeVersion: ">=1.16.0-0"

--- a/library/ix-dev/charts/wg-easy/templates/deployment.yaml
+++ b/library/ix-dev/charts/wg-easy/templates/deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ template "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
-  name: {{ template "common.names.fullname" . }}
+  name: {{ template "common.names.fullname" . }}-wg
   labels:
     app: {{ template "common.names.name" . }}
     chart: {{ template "common.names.chart" . }}


### PR DESCRIPTION
While working on #1403 I realized that because the deployment name generation logic is the same on both common libraries, we were having issues on upgrade.

Specifically, Deployment labels/selectorLabels are immutable so when Helm tries to send a PATCH to k8s api, it fails.
While this can be "fixed" manually by deleting the `Deployment` by using `kubectl`, it's not user friendly and prone to errors.

Waqar suggest a nice idea, to use different name on deployment, this works, but instead of having to add suffixes on the new common library just for the migration, I'm renaming current deployment name so when we migrate to the new common the name won't match. Which will allow helm to create the new deployment and delete the old one.
