### PR TITLE
Tdarr: Update logo

### DIFF
--- a/library/ix-dev/community/tdarr/Chart.yaml
+++ b/library/ix-dev/community/tdarr/Chart.yaml
@@ -3,7 +3,7 @@ description: Tdarr is a Distributed Transcoding System
 annotations:
   title: Tdarr
 type: application
-version: 1.0.14
+version: 1.0.15
 apiVersion: v2
 appVersion: '2.00.21'
 kubeVersion: '>=1.16.0-0'
@@ -16,7 +16,7 @@ dependencies:
     repository: file://../../../common
     version: 1.0.12
 home: https://home.tdarr.io/
-icon: https://home.tdarr.io/static/media/logo3-min.246d6df4.png
+icon: https://home.tdarr.io/static/media/logo3-min.246d6df44c7f16ddebaf.png
 sources:
   - https://home.tdarr.io/
   - https://github.com/truenas/charts/tree/master/community/tdarr

--- a/library/ix-dev/community/tdarr/item.yaml
+++ b/library/ix-dev/community/tdarr/item.yaml
@@ -1,4 +1,4 @@
-icon_url: hhttps://home.tdarr.io/static/media/logo3-min.246d6df44c7f16ddebaf.png
+icon_url: https://home.tdarr.io/static/media/logo3-min.246d6df44c7f16ddebaf.png
 categories:
   - media
 screenshots:

--- a/library/ix-dev/community/tdarr/item.yaml
+++ b/library/ix-dev/community/tdarr/item.yaml
@@ -1,4 +1,4 @@
-icon_url: https://home.tdarr.io/static/media/logo3-min.246d6df4.png
+icon_url: hhttps://home.tdarr.io/static/media/logo3-min.246d6df44c7f16ddebaf.png
 categories:
   - media
 screenshots:


### PR DESCRIPTION
Currently, the source of the Tdarr chart icon is [a broken link](https://home.tdarr.io/static/media/logo3-min.246d6df4.png):
![Screenshot 2023-07-26 at 21 24 41](https://github.com/truenas/charts/assets/1167401/ac9c3043-91bd-48e6-ad7b-6162bb870241)

This PR updates the link for the icon of the Tdarr chart.