### PR TITLE
NAS-123639 / 24.04 / Adds fields for max execution time and memory limit of PHP

### DIFF
--- a/library/ix-dev/charts/nextcloud/Chart.yaml
+++ b/library/ix-dev/charts/nextcloud/Chart.yaml
@@ -4,7 +4,7 @@ description: A file sharing server that puts the control and security of your ow
 annotations:
   title: Nextcloud
 type: application
-version: 1.6.39
+version: 1.6.40
 apiVersion: v2
 appVersion: 27.0.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/nextcloud/ci/test-values.yaml
+++ b/library/ix-dev/charts/nextcloud/ci/test-values.yaml
@@ -18,6 +18,8 @@ nextcloud:
   install_ffmpeg: true
   install_smbclient: true
   max_upload_size: 5
+  max_execution_time: 30
+  php_memory_limit: 512
   opcache_memory_consumption: 128
   password: changeme
   username: admin

--- a/library/ix-dev/charts/nextcloud/questions.yaml
+++ b/library/ix-dev/charts/nextcloud/questions.yaml
@@ -148,6 +148,23 @@ questions:
             default: 3
             min: 1
             required: true
+        - variable: max_execution_time
+          label: "Max Execution Time (Seconds)"
+          description: "Configures the max execution time of php"
+          schema:
+            type: int
+            default: 30
+            min: 30
+            required: true
+        - variable: php_memory_limit
+          label: "PHP Memory Limit (Mega Bytes)"
+          description: "Configures the memory limit of php"
+          schema:
+            type: int
+            default: 512
+            min: 128
+            max: 4096
+            required: true
         - variable: opcache_memory_consumption
           label: "Opcache Memory Consumption (Mega Bytes)"
           description: "Configures the memory consumption of the opcache"

--- a/library/ix-dev/charts/nextcloud/templates/deployment.yaml
+++ b/library/ix-dev/charts/nextcloud/templates/deployment.yaml
@@ -78,6 +78,7 @@ spec: {{ include "common.deployment.common_spec" . | nindent 2 }}
         {{ $envList = mustAppend $envList (dict "name" "POSTGRES_DB" "value" (include "postgres.DatabaseName" .)) }}
         {{ $envList = mustAppend $envList (dict "name" "NEXTCLOUD_DATA_DIR" "value" .Values.nextcloud.datadir) }}
         {{ $envList = mustAppend $envList (dict "name" "PHP_UPLOAD_LIMIT" "value" (printf "%vG" (.Values.nextcloud.max_upload_size | default 3))) }}
+        {{ $envList = mustAppend $envList (dict "name" "PHP_MEMORY_LIMIT" "value" (printf "%vM" (.Values.nextcloud.php_memory_limit | default 512))) }}
         {{ if eq (include "nginx.certAvailable" .) "true" }}
         {{ $envList = mustAppend $envList (dict "name" "APACHE_DISABLE_REWRITE_IP" "value" "1") }}
           {{ if and .Values.nextcloud.host .Values.service.nodePort }}
@@ -183,6 +184,11 @@ spec: {{ include "common.deployment.common_spec" . | nindent 2 }}
           # after the default opcache file nextcloud provides.
           mountPath: /usr/local/etc/php/conf.d/opcache-z-99.ini
           subPath: opcache.ini
+        - name: nextcloud-configuration
+          # We use -z-99 to ensure that this file is loaded
+          # after the default php config file nextcloud provides.
+          mountPath: /usr/local/etc/php/conf.d/nextcloud-z-99.ini
+          subPath: php.ini
         {{ range $index, $hostPathConfiguration := .Values.extraAppVolumeMounts }}
         - name: extrappvolume-{{ $index }}
           mountPath: {{ $hostPathConfiguration.mountPath }}

--- a/library/ix-dev/charts/nextcloud/templates/nextcloud-configmap.yaml
+++ b/library/ix-dev/charts/nextcloud/templates/nextcloud-configmap.yaml
@@ -5,3 +5,6 @@ metadata:
 data:
   opcache.ini: |
     opcache.memory_consumption={{ .Values.nextcloud.opcache_memory_consumption }}
+
+  php.ini: |
+    max_execution_time={{ .Values.nextcloud.max_execution_time }}


### PR DESCRIPTION
Fixes: https://github.com/truenas/charts/issues/1443

There are cases that you need higher max_execution_time than the default (30sec) provided from PHP.
Example: `Password` app [requires at least 2 hours](https://git.mdns.eu/nextcloud/passwords/-/wikis/Administrators/Services/Password-Security-Check-Services#requirements)

Also adds a field for PHP memory limit which is often also tuned.