### PR TITLE
Update Chart.yaml to fix Minio app version

### DIFF
--- a/charts/minio/1.7.17/Chart.yaml
+++ b/charts/minio/1.7.17/Chart.yaml
@@ -5,7 +5,7 @@ annotations:
 type: application
 version: 1.7.17
 apiVersion: v2
-appVersion: '2023-03-13'
+appVersion: '2023-07-21'
 kubeVersion: '>=1.16.0-0'
 maintainers:
   - name: truenas


### PR DESCRIPTION
Hi, I just did a fresh install of minio but the version 2023-03-13 seemed a bit old. 

I had a look at the latest commit to the minio charts folder: https://github.com/truenas/charts/commit/acb973d1b21391ee83d884810dbc2d1d7301efd6

It seems that two changes were made:
1. the image version was changed from 2023-03-13 to 2023-07-21
2. version: 1.7.16 changed to version: 1.7.17 

I think @sonicaj missed changing the `appVersion` in the Chart.yml file so the correct image is displayed: 
![image](https://github.com/truenas/charts/assets/60941345/5e6257a1-6867-408a-9f05-102db5046d41)

Changing the `appVersion` to `2023-07-21` in Chart.yml should display the correct image version in the preview.