### PR TITLE
NAS-123669 / 24.04 / Fix upload size limit on apache (nextcloud)

### DIFF
--- a/library/ix-dev/charts/nextcloud/Chart.yaml
+++ b/library/ix-dev/charts/nextcloud/Chart.yaml
@@ -4,7 +4,7 @@ description: A file sharing server that puts the control and security of your ow
 annotations:
   title: Nextcloud
 type: application
-version: 1.6.41
+version: 1.6.42
 apiVersion: v2
 appVersion: 27.0.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/nextcloud/templates/deployment.yaml
+++ b/library/ix-dev/charts/nextcloud/templates/deployment.yaml
@@ -190,6 +190,10 @@ spec: {{ include "common.deployment.common_spec" . | nindent 2 }}
           # after the default php config file nextcloud provides.
           mountPath: /usr/local/etc/php/conf.d/nextcloud-z-99.ini
           subPath: php.ini
+        - name: nextcloud-configuration
+          # https://github.com/nextcloud/docker/issues/1796
+          mountPath: /etc/apache2/conf-enabled/limitrequestbody.conf
+          subPath: limitrequestbody.conf
         {{ range $index, $hostPathConfiguration := .Values.extraAppVolumeMounts }}
         - name: extrappvolume-{{ $index }}
           mountPath: {{ $hostPathConfiguration.mountPath }}

--- a/library/ix-dev/charts/nextcloud/templates/nextcloud-configmap.yaml
+++ b/library/ix-dev/charts/nextcloud/templates/nextcloud-configmap.yaml
@@ -1,3 +1,4 @@
+{{ $bytesGB := 1073741824 }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,3 +9,6 @@ data:
 
   php.ini: |
     max_execution_time={{ .Values.nextcloud.max_execution_time }}
+
+  limitrequestbody.conf: |
+    LimitRequestBody {{ mul .Values.nextcloud.max_upload_size $bytesGB }}


### PR DESCRIPTION
Fixes #1455 

(Also upstream linked issue https://github.com/nextcloud/docker/issues/1796)

Even after all the config files configured correctly nextcloud will not accept files bigger than 1GB 
(From my testing that applies only on WebDav, or at least when an upload happens without chunking)

From [http's docs](https://httpd.apache.org/docs/2.4/mod/core.html#limitrequestbody) the `LimitRequestBody` was initially `0` (unlimited) and now its 1GB (1073741824 bytes) 
```
In Apache HTTP Server 2.4.53 and earlier, the default value was 0 (unlimited)
```

---

Instead of just setting `LimitRequestBody` to `0`, I've opted to calculate it based on the `max_upload_size` defined by the user.