### PR TITLE
ddns-updater: add missing OVH provider IP setting

### DIFF
--- a/library/ix-dev/community/ddns-updater/Chart.yaml
+++ b/library/ix-dev/community/ddns-updater/Chart.yaml
@@ -3,7 +3,7 @@ description: Lightweight universal DDNS Updater with web UI
 annotations:
   title: DDNS Updater
 type: application
-version: 1.0.13
+version: 1.0.14
 apiVersion: v2
 appVersion: 'v2.5.0'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/ddns-updater/questions.yaml
+++ b/library/ix-dev/community/ddns-updater/questions.yaml
@@ -823,6 +823,13 @@ questions:
                         type: string
                         private: true
                         show_if: [["provider", "=", "ovh"]]
+                    - variable: ovhProviderIP
+                      label: OVH Provider IP
+                      description: OVH Provider IP.
+                      schema:
+                        type: boolean
+                        show_if: [["provider", "=", "ovh"]]
+                        default: false
 
                     # Porkbun
                     - variable: porkbunApiKey


### PR DESCRIPTION
The `provider IP` parameter is currently missing when configuring `ddns-updater` with the OVH provider.
The setting is added in `questions.yaml`.

The error currently visible in the logs:
```
ERROR configuration given: json: cannot unmarshal string into Go struct field .provider_ip of type bool
```