### PR TITLE
NAS-123856 / 24.04 / take size into account when creating a unique name

### DIFF
--- a/library/common-test/tests/persistence/pv_data_test.yaml
+++ b/library/common-test/tests/persistence/pv_data_test.yaml
@@ -18,6 +18,17 @@ tests:
           type: nfs-pv-pvc
           server: my-server2
           share: /my-path2
+          size: 2Gi
+          mountOptions:
+            - key: hard
+            - key: nfsvers
+              value: '{{ .Values.version }}'
+        my-volume3:
+          enabled: true
+          type: nfs-pv-pvc
+          server: my-server2
+          share: /my-path2
+          size: 3Gi
           mountOptions:
             - key: hard
             - key: nfsvers
@@ -33,12 +44,12 @@ tests:
             capacity:
               storage: 1Gi
             persistentVolumeReclaimPolicy: Delete
-            storageClassName: release-name-common-test-my-volume1-1088882375
+            storageClassName: release-name-common-test-my-volume1-1451165653
             accessModes:
               - ReadWriteOnce
             csi:
               driver: nfs.csi.k8s.io
-              volumeHandle: my-server/my-path#release-name-common-test-my-volume1-1088882375
+              volumeHandle: my-server/my-path#release-name-common-test-my-volume1-1451165653
               volumeAttributes:
                 server: my-server
                 share: /my-path
@@ -54,7 +65,7 @@ tests:
             resources:
               requests:
                 storage: 1Gi
-            storageClassName: release-name-common-test-my-volume1-1088882375
+            storageClassName: release-name-common-test-my-volume1-1451165653
       - documentIndex: &otherPvDoc 2
         isKind:
           of: PersistentVolume
@@ -63,9 +74,9 @@ tests:
           path: spec
           value:
             capacity:
-              storage: 1Gi
+              storage: 2Gi
             persistentVolumeReclaimPolicy: Delete
-            storageClassName: release-name-common-test-my-volume2-1303447339
+            storageClassName: release-name-common-test-my-volume2-1702692922
             accessModes:
               - ReadWriteOnce
             mountOptions:
@@ -73,10 +84,58 @@ tests:
               - nfsvers=4.1
             csi:
               driver: nfs.csi.k8s.io
-              volumeHandle: my-server2/my-path2#release-name-common-test-my-volume2-1303447339
+              volumeHandle: my-server2/my-path2#release-name-common-test-my-volume2-1702692922
               volumeAttributes:
                 server: my-server2
                 share: /my-path2
+      - documentIndex: &otherPvcDoc 3
+        isKind:
+          of: PersistentVolumeClaim
+      - documentIndex: *otherPvcDoc
+        equal:
+          path: spec
+          value:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 2Gi
+            storageClassName: release-name-common-test-my-volume2-1702692922
+      - documentIndex: &thirdPvDoc 4
+        isKind:
+          of: PersistentVolume
+      - documentIndex: *thirdPvDoc
+        equal:
+          path: spec
+          value:
+            capacity:
+              storage: 3Gi
+            persistentVolumeReclaimPolicy: Delete
+            storageClassName: release-name-common-test-my-volume3-1704265787
+            accessModes:
+              - ReadWriteOnce
+            mountOptions:
+              - hard
+              - nfsvers=4.1
+            csi:
+              driver: nfs.csi.k8s.io
+              volumeHandle: my-server2/my-path2#release-name-common-test-my-volume3-1704265787
+              volumeAttributes:
+                server: my-server2
+                share: /my-path2
+      - documentIndex: &thirdPvcDoc 5
+        isKind:
+          of: PersistentVolumeClaim
+      - documentIndex: *thirdPvcDoc
+        equal:
+          path: spec
+          value:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 3Gi
+            storageClassName: release-name-common-test-my-volume3-1704265787
 
   - it: should create smb pv with csi
     set:
@@ -96,6 +155,21 @@ tests:
           share: my-share2
           username: my-user2
           password: my-password2
+          size: 2Gi
+          mountOptions:
+            - key: hard
+            - key: uid
+              value: 99999999999
+            - key: vers
+              value: '{{ .Values.version }}'
+        my-volume3:
+          enabled: true
+          type: smb-pv-pvc
+          server: my-server2
+          share: my-share2
+          username: my-user2
+          password: my-password2
+          size: 3Gi
           mountOptions:
             - key: hard
             - key: uid
@@ -122,16 +196,16 @@ tests:
             capacity:
               storage: 1Gi
             persistentVolumeReclaimPolicy: Delete
-            storageClassName: release-name-common-test-my-volume1-1117390590
+            storageClassName: release-name-common-test-my-volume1-1479673868
             accessModes:
               - ReadWriteOnce
             csi:
               driver: smb.csi.k8s.io
-              volumeHandle: my-server/my-share#release-name-common-test-my-volume1-1117390590
+              volumeHandle: my-server/my-share#release-name-common-test-my-volume1-1479673868
               volumeAttributes:
                 source: //my-server/my-share
               nodeStageSecretRef:
-                name: release-name-common-test-my-volume1-1117390590
+                name: release-name-common-test-my-volume1-1479673868
                 namespace: release-namespace
       - documentIndex: &pvcDoc 2
         isKind:
@@ -145,7 +219,7 @@ tests:
             resources:
               requests:
                 storage: 1Gi
-            storageClassName: release-name-common-test-my-volume1-1117390590
+            storageClassName: release-name-common-test-my-volume1-1479673868
       - documentIndex: &otherSecretDoc 3
         isKind:
           of: Secret
@@ -163,9 +237,9 @@ tests:
           path: spec
           value:
             capacity:
-              storage: 1Gi
+              storage: 2Gi
             persistentVolumeReclaimPolicy: Delete
-            storageClassName: release-name-common-test-my-volume2-1335560034
+            storageClassName: release-name-common-test-my-volume2-1734805617
             accessModes:
               - ReadWriteOnce
             mountOptions:
@@ -174,11 +248,11 @@ tests:
               - vers=3.0
             csi:
               driver: smb.csi.k8s.io
-              volumeHandle: my-server2/my-share2#release-name-common-test-my-volume2-1335560034
+              volumeHandle: my-server2/my-share2#release-name-common-test-my-volume2-1734805617
               volumeAttributes:
                 source: //my-server2/my-share2
               nodeStageSecretRef:
-                name: release-name-common-test-my-volume2-1335560034
+                name: release-name-common-test-my-volume2-1734805617
                 namespace: release-namespace
       - documentIndex: &otherPvcDoc 5
         isKind:
@@ -191,5 +265,52 @@ tests:
               - ReadWriteOnce
             resources:
               requests:
-                storage: 1Gi
-            storageClassName: release-name-common-test-my-volume2-1335560034
+                storage: 2Gi
+            storageClassName: release-name-common-test-my-volume2-1734805617
+      - documentIndex: &thirdSecretDoc 6
+        isKind:
+          of: Secret
+      - documentIndex: *thirdSecretDoc
+        equal:
+          path: stringData
+          value:
+            username: my-user2
+            password: my-password2
+      - documentIndex: &thirdPvDoc 7
+        isKind:
+          of: PersistentVolume
+      - documentIndex: *thirdPvDoc
+        equal:
+          path: spec
+          value:
+            capacity:
+              storage: 3Gi
+            persistentVolumeReclaimPolicy: Delete
+            storageClassName: release-name-common-test-my-volume3-1736378482
+            accessModes:
+              - ReadWriteOnce
+            mountOptions:
+              - hard
+              - uid=99999999999
+              - vers=3.0
+            csi:
+              driver: smb.csi.k8s.io
+              volumeHandle: my-server2/my-share2#release-name-common-test-my-volume3-1736378482
+              volumeAttributes:
+                source: //my-server2/my-share2
+              nodeStageSecretRef:
+                name: release-name-common-test-my-volume3-1736378482
+                namespace: release-namespace
+      - documentIndex: &thirdPvcDoc 8
+        isKind:
+          of: PersistentVolumeClaim
+      - documentIndex: *thirdPvcDoc
+        equal:
+          path: spec
+          value:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 3Gi
+            storageClassName: release-name-common-test-my-volume3-1736378482

--- a/library/common-test/tests/persistence/pv_name_test.yaml
+++ b/library/common-test/tests/persistence/pv_name_test.yaml
@@ -27,7 +27,7 @@ tests:
       - documentIndex: *pvDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-volume1-1342834583
+          value: release-name-common-test-my-volume1-1740507301
       - documentIndex: &pvcDoc 1
         isKind:
           of: PersistentVolumeClaim
@@ -37,7 +37,7 @@ tests:
       - documentIndex: *pvcDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-volume1-1342834583
+          value: release-name-common-test-my-volume1-1740507301
       - documentIndex: &secretDoc 2
         isKind:
           of: Secret
@@ -47,7 +47,7 @@ tests:
       - documentIndex: *secretDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-volume2-1247545192
+          value: release-name-common-test-my-volume2-1627523190
       - documentIndex: &pvDoc 3
         isKind:
           of: PersistentVolume
@@ -57,7 +57,7 @@ tests:
       - documentIndex: *pvDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-volume2-1247545192
+          value: release-name-common-test-my-volume2-1627523190
       - documentIndex: &otherPvcDoc 4
         isKind:
           of: PersistentVolumeClaim
@@ -67,4 +67,4 @@ tests:
       - documentIndex: *otherPvcDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-volume2-1247545192
+          value: release-name-common-test-my-volume2-1627523190

--- a/library/common-test/tests/pod/volume_nfs-pv-pvc_test.yaml
+++ b/library/common-test/tests/pod/volume_nfs-pv-pvc_test.yaml
@@ -21,6 +21,13 @@ tests:
           type: nfs-pv-pvc
           server: my-server2
           share: /my-path2
+          size: 2Gi
+        my-volume3:
+          enabled: true
+          type: nfs-pv-pvc
+          server: my-server2
+          share: /my-path2
+          size: 3Gi
     asserts:
       - documentIndex: &pvDoc 0
         isKind:
@@ -28,15 +35,15 @@ tests:
       - documentIndex: *pvDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-volume1-1088882375
+          value: release-name-common-test-my-volume1-1451165653
       - documentIndex: &otherPvDoc 2
         isKind:
           of: PersistentVolume
       - documentIndex: *otherPvDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-volume2-1303447339
-      - documentIndex: &deploymentDoc 4
+          value: release-name-common-test-my-volume2-1702692922
+      - documentIndex: &deploymentDoc 6
         isKind:
           of: Deployment
       - documentIndex: *deploymentDoc
@@ -45,11 +52,18 @@ tests:
           content:
             name: my-volume1
             persistentVolumeClaim:
-              claimName: release-name-common-test-my-volume1-1088882375
+              claimName: release-name-common-test-my-volume1-1451165653
       - documentIndex: *deploymentDoc
         contains:
           path: spec.template.spec.volumes
           content:
             name: my-volume2
             persistentVolumeClaim:
-              claimName: release-name-common-test-my-volume2-1303447339
+              claimName: release-name-common-test-my-volume2-1702692922
+      - documentIndex: *deploymentDoc
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: my-volume3
+            persistentVolumeClaim:
+              claimName: release-name-common-test-my-volume3-1704265787

--- a/library/common-test/tests/pod/volume_smb-pv-pvc_test.yaml
+++ b/library/common-test/tests/pod/volume_smb-pv-pvc_test.yaml
@@ -25,6 +25,15 @@ tests:
           share: my-share2
           username: my-user2
           password: my-pass2
+          size: 2Gi
+        my-volume3:
+          enabled: true
+          type: smb-pv-pvc
+          server: my-server2
+          share: my-share2
+          username: my-user2
+          password: my-pass2
+          size: 3Gi
     asserts:
       - documentIndex: &pvDoc 1
         isKind:
@@ -32,15 +41,15 @@ tests:
       - documentIndex: *pvDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-volume1-1117390590
+          value: release-name-common-test-my-volume1-1479673868
       - documentIndex: &otherPvDoc 4
         isKind:
           of: PersistentVolume
       - documentIndex: *otherPvDoc
         equal:
           path: metadata.name
-          value: release-name-common-test-my-volume2-1335560034
-      - documentIndex: &deploymentDoc 6
+          value: release-name-common-test-my-volume2-1734805617
+      - documentIndex: &deploymentDoc 9
         isKind:
           of: Deployment
       - documentIndex: *deploymentDoc
@@ -49,11 +58,18 @@ tests:
           content:
             name: my-volume1
             persistentVolumeClaim:
-              claimName: release-name-common-test-my-volume1-1117390590
+              claimName: release-name-common-test-my-volume1-1479673868
       - documentIndex: *deploymentDoc
         contains:
           path: spec.template.spec.volumes
           content:
             name: my-volume2
             persistentVolumeClaim:
-              claimName: release-name-common-test-my-volume2-1335560034
+              claimName: release-name-common-test-my-volume2-1734805617
+      - documentIndex: *deploymentDoc
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: my-volume3
+            persistentVolumeClaim:
+              claimName: release-name-common-test-my-volume3-1736378482

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A library chart for iX Official Catalog
 type: library
-version: 1.1.0
+version: 1.1.1
 appVersion: v1
 annotations:
   title: Common Library Chart

--- a/library/common/templates/lib/pod/volumes/_pvc.tpl
+++ b/library/common/templates/lib/pod/volumes/_pvc.tpl
@@ -14,7 +14,8 @@ objectData: The object data to be used to render the volume.
   {{- end -}}
 
   {{- if mustHas $objectData.type (list "nfs-pv-pvc" "smb-pv-pvc") -}}
-    {{- $hashValues := (printf "%s-%s" $objectData.server $objectData.share) -}}
+    {{- $size := $objectData.size | default $rootCtx.Values.fallbackDefaults.pvcSize -}}
+    {{- $hashValues := (printf "%s-%s-%s" $size $objectData.server $objectData.share) -}}
     {{- if $objectData.domain -}}
       {{- $hashValues = (printf "%s-%s" $hashValues $objectData.domain) -}}
     {{- end -}}

--- a/library/common/templates/spawner/_pvc.tpl
+++ b/library/common/templates/spawner/_pvc.tpl
@@ -38,7 +38,8 @@
           {{/* Validate SMB CSI */}}
           {{- include "ix.v1.common.lib.storage.smbCSI.validation" (dict "rootCtx" $ "objectData" $objectData) -}}
 
-          {{- $hashValues := (printf "%s-%s" $objectData.server $objectData.share) -}}
+          {{- $size := $objectData.size | default $.Values.fallbackDefaults.pvcSize -}}
+          {{- $hashValues := (printf "%s-%s-%s" $size $objectData.server $objectData.share) -}}
           {{- if $objectData.domain -}}
             {{- $hashValues = (printf "%s-%s" $hashValues $objectData.domain) -}}
           {{- end -}}
@@ -71,7 +72,8 @@
           {{/* Validate NFS CSI */}}
           {{- include "ix.v1.common.lib.storage.nfsCSI.validation" (dict "rootCtx" $ "objectData" $objectData) -}}
 
-          {{- $hashValues := (printf "%s-%s" $objectData.server $objectData.share) -}}
+          {{- $size := $objectData.size | default $.Values.fallbackDefaults.pvcSize -}}
+          {{- $hashValues := (printf "%s-%s-%s" $size $objectData.server $objectData.share) -}}
           {{/* Create a unique name taking into account server and share,
               without this, changing one of those values is not possible */}}
           {{- $hash := adler32sum $hashValues -}}


### PR DESCRIPTION
When creating unique pv/pvc names, we have to also take size into account.
As we need to recreate pv/pvc under a different name, as "resize" is not available with static generated pv's.

Also added tests to make sure same params with different size actually produces different name.