### PR TITLE
NAS-124158 / 24.04 / fix collabora upgrade strategy

### DIFF
--- a/library/ix-dev/charts/collabora/upgrade_strategy
+++ b/library/ix-dev/charts/collabora/upgrade_strategy
@@ -16,6 +16,9 @@ def newer_mapping(image_tags):
     for tag in temp_tags:
         tag = tag.split('.')
         for i in range(len(tag)):
+            # Ignore the first two parts as they are supposed to have leading zeros
+            if i in [0, 1]:
+                continue
             # Add leading zero to single digit numbers
             if len(tag[i]) == 1:
                 tag[i] = '0' + tag[i]
@@ -26,9 +29,21 @@ def newer_mapping(image_tags):
     if not version:
         return {}
 
+    cleanVersion = ""
+    for idx, part in enumerate(version.split('.')):
+        # Ignore the first two parts as they are supposed to have leading zeros
+        if idx in [0, 1]:
+            cleanVersion += part + '.'
+            continue
+        # Remove leading zero
+        cleanVersion += part.lstrip('0') + '.'
+
+    # Remove trailing dot
+    cleanVersion = cleanVersion.rstrip('.')
+
     return {
-        'tags': {key: tags[version]},
-        'app_version': version,
+        'tags': {key: cleanVersion},
+        'app_version': cleanVersion,
     }
 
 


### PR DESCRIPTION
It appears that the first 2 parts of the versioning is year.month, which are supposed to have the leading zeros, while the rest should not.

I did a few tests with few of their latest tags on dockerhub and appears to work.