### PR TITLE
add additional mount for user data

### DIFF
--- a/charts/nextcloud/1.6.48/questions.yaml
+++ b/charts/nextcloud/1.6.48/questions.yaml
@@ -137,7 +137,7 @@ questions:
             required: true
         - variable: datadir
           label: "Nextcloud data directory"
-          description: "Configures the data directory where nextcloud stores all files from the users"
+          description: "Configures the data directory where nextcloud stores all files from the users (inside the container). When changing this, make sure to specify a host path for Nextcloud User Data Volume in the section storage."
           schema:
             type: path
             default: "/var/www/html/data"
@@ -282,6 +282,43 @@ questions:
                   subquestions:
                     - variable: hostPath
                       label: "Host Path for Nextcloud Data Volume"
+                      schema:
+                        type: hostpath
+                        required: true
+        - variable: nextcloud-userdata
+          label: "Nextcloud User Data Volume"
+          schema:
+            type: dict
+            show_if: [[ "nextcloud.datadir", "!=", "/var/www/html/data" ]]
+            attrs:
+              - variable: datasetName
+                label: "Nextcloud User Data Volume Name"
+                schema:
+                  type: string
+                  hidden: true
+                  $ref:
+                    - "normalize/ixVolume"
+                  show_if: [["hostPathEnabled", "=", false]]
+                  default: "ix-nextcloud_userdata"
+                  editable: false
+              - variable: mountPath
+                label: "Nextcloud UserData Mount Path"
+                description: "Path where the volume will be mounted inside the pod"
+                schema:
+                  type: path
+                  hidden: true
+                  editable: false
+                  default: nextcloud.datadir
+              - variable: hostPathEnabled
+                label: "Enable Host Path for Nextcloud User Data Volume"
+                description: "Path on host that will be mounted at the location of the Nextcloud data directory in the container. Set this only if you moved the Nextcloud data directory out of /var/www/html/"
+                schema:
+                  type: boolean
+                  default: false
+                  show_subquestions_if: true
+                  subquestions:
+                    - variable: hostPath
+                      label: "Host Path for Nextcloud User Data Volume"
                       schema:
                         type: hostpath
                         required: true

--- a/charts/nextcloud/1.6.48/templates/cronjob.yaml
+++ b/charts/nextcloud/1.6.48/templates/cronjob.yaml
@@ -57,7 +57,7 @@ spec:
                 mountPath: /var/www/html
                 subPath: "html"
               - name: nextcloud-data
-                mountPath: {{ .Values.nextcloud.datadir }}
+                mountPath: /var/www/html/data
                 subPath: "data"
               - name: nextcloud-data
                 mountPath: /var/www/html/config
@@ -71,6 +71,10 @@ spec:
               - name: nextcloud-data
                 mountPath: /var/www/html/themes
                 subPath: "themes"
+              {{ if ne .Values.nextcloud.datadir "/var/www/html/data" }}
+              - name: nextcloud-userdata
+                mountPath: {{ .Values.nextcloud.datadir }}
+              {{ end }}
           volumes:
           {{ if .Values.appVolumeMounts }}
           {{- include "common.storage.configureAppVolumes" .Values | nindent 12 }}

--- a/charts/nextcloud/1.6.48/templates/deployment.yaml
+++ b/charts/nextcloud/1.6.48/templates/deployment.yaml
@@ -170,7 +170,7 @@ spec: {{ include "common.deployment.common_spec" . | nindent 2 }}
           mountPath: /var/www/html
           subPath: "html"
         - name: nextcloud-data
-          mountPath: {{ .Values.nextcloud.datadir }}
+          mountPath: /var/www/html/data
           subPath: "data"
         - name: nextcloud-data
           mountPath: /var/www/html/config
@@ -184,6 +184,10 @@ spec: {{ include "common.deployment.common_spec" . | nindent 2 }}
         - name: nextcloud-data
           mountPath: /var/www/html/themes
           subPath: "themes"
+        {{ if ne .Values.nextcloud.datadir "/var/www/html/data" }}
+        - name: nextcloud-userdata
+          mountPath: {{ .Values.nextcloud.datadir }}
+        {{ end }}
         - name: nextcloud-configuration
           # We use -z-99 to ensure that this file is loaded
           # after the default opcache file nextcloud provides.


### PR DESCRIPTION
As described in  #1452, currently you can not mount the nextcloud user data to a different dataset than the other nextcloud data (content from `/var/www/html`).
You are able to change the user data directory inside the nextcloud container, however the host path volume configuration will put it into one directory together with the `html` folder on the host.

This PR adds another volume for the user data to provide the user with the possibility to separate user data from the `html`-folder.