### PR TITLE
fix collabora's upgrade strategy

### DIFF
--- a/library/ix-dev/charts/collabora/upgrade_strategy
+++ b/library/ix-dev/charts/collabora/upgrade_strategy
@@ -13,6 +13,8 @@ def newer_mapping(image_tags):
     key = list(image_tags.keys())[0]
     temp_tags = {t: t for t in image_tags[key] if RE_STABLE_VERSION.fullmatch(t)}
     tags = {}
+
+    # Format tags so they can be parsed by datetime_versioning
     for tag in temp_tags:
         tag = tag.split('.')
         for i in range(len(tag)):
@@ -25,18 +27,20 @@ def newer_mapping(image_tags):
         tag = '.'.join(tag)
         tags[tag] = tag
 
-    version = datetime_versioning(list(tags), '%y.%m.%d.%H.%M')
+    # Get the latest version
+    version = datetime_versioning(list(tags), '%y.%m.%S.%H.%M')
     if not version:
         return {}
 
     cleanVersion = ""
+    # Covert the tag back to the original format
     for idx, part in enumerate(version.split('.')):
         # Ignore the first two parts as they are supposed to have leading zeros
         if idx in [0, 1]:
             cleanVersion += part + '.'
             continue
-        # Remove leading zero
-        cleanVersion += part.lstrip('0') + '.'
+        if len(part) == 2 and part[0] == '0':
+            cleanVersion += part[1] + '.'
 
     # Remove trailing dot
     cleanVersion = cleanVersion.rstrip('.')
@@ -48,9 +52,10 @@ def newer_mapping(image_tags):
 
 
 if __name__ == '__main__':
-    try:
-        versions_json = json.loads(sys.stdin.read())
-    except ValueError:
-        raise ValueError('Invalid json specified')
-
+    # try:
+    #     versions_json = json.loads(sys.stdin.read())
+    # except ValueError:
+    #     raise ValueError('Invalid json specified')
+    with open('test.json') as f:
+        versions_json = json.load(f)
     print(json.dumps(newer_mapping(versions_json)))

--- a/library/ix-dev/charts/collabora/upgrade_strategy
+++ b/library/ix-dev/charts/collabora/upgrade_strategy
@@ -28,7 +28,7 @@ def newer_mapping(image_tags):
         tags[tag] = tag
 
     # Get the latest version
-    version = datetime_versioning(list(tags), '%y.%m.%S.%H.%M')
+    version = datetime_versioning(list(tags), '%y.%m.%H.%M.%S')
     if not version:
         return {}
 
@@ -52,10 +52,9 @@ def newer_mapping(image_tags):
 
 
 if __name__ == '__main__':
-    # try:
-    #     versions_json = json.loads(sys.stdin.read())
-    # except ValueError:
-    #     raise ValueError('Invalid json specified')
-    with open('test.json') as f:
-        versions_json = json.load(f)
+    try:
+        versions_json = json.loads(sys.stdin.read())
+    except ValueError:
+        raise ValueError('Invalid json specified')
+
     print(json.dumps(newer_mapping(versions_json)))


### PR DESCRIPTION
FIxes #1509 

Handles cases that the last 3 parts of the version scheme are `00`.