### PR TITLE
collabora - allowed domains and optional webui

### DIFF
--- a/library/ix-dev/charts/collabora/Chart.yaml
+++ b/library/ix-dev/charts/collabora/Chart.yaml
@@ -5,7 +5,7 @@ description: |
 annotations:
   title: Collabora
 type: application
-version: 1.2.17
+version: 1.2.18
 apiVersion: v2
 appVersion: 23.05.4.2.1
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/collabora/ci/http-values.yaml
+++ b/library/ix-dev/charts/collabora/ci/http-values.yaml
@@ -2,7 +2,10 @@ nodePort: 31980
 config:
   DONT_GEN_SSL_CERT: 'true'
   dictionaries: de_DE en_GB en_US es_ES fr_FR it nl pt_BR pt_PT ru
-  domain: nextcloud\.domain\.tld|othernextcloud\.domain\.tld
+  enableWebUI: false
+  aliasgroup1:
+    - nextcloud.domain.tld
+    - othernextcloud.domain.tld
   extra_params: --o:welcome.enable=false --o:user_interface.mode=notebookbar --o:ssl.termination=true
     --o:ssl.enable=false --o:net.proto=IPv4 --o:net.post_allow.host[0]=.+ --o:storage.wopi.host[0]=.+
   password: changeme

--- a/library/ix-dev/charts/collabora/ci/https-values.yaml
+++ b/library/ix-dev/charts/collabora/ci/https-values.yaml
@@ -3,7 +3,10 @@ nodePort: 31980
 config:
   DONT_GEN_SSL_CERT: 'true'
   dictionaries: de_DE en_GB en_US es_ES fr_FR it nl pt_BR pt_PT ru
-  domain: nextcloud\.domain\.tld|othernextcloud\.domain\.tld
+  enableWebUI: true
+  aliasgroup1:
+    - nextcloud.domain.tld
+    - othernextcloud.domain.tld
   extra_params: --o:welcome.enable=false --o:user_interface.mode=notebookbar --o:ssl.termination=true
     --o:ssl.enable=false --o:net.proto=IPv4 --o:net.post_allow.host[0]=.+ --o:storage.wopi.host[0]=.+
   password: changeme

--- a/library/ix-dev/charts/collabora/questions.yaml
+++ b/library/ix-dev/charts/collabora/questions.yaml
@@ -34,8 +34,17 @@ questions:
             type: string
             $ref:
               - "definitions/timezone"
+        - variable: enableWebUI
+          label: "Enable WebUI"
+          description: |
+            Enable WebUI for Collabora
+            If you enable this, you will need to set a username and password</br>
+          schema:
+            type: boolean
+            default: true
         - variable: username
           label: "Username for WebUI"
+          show_if: [[enableWebUI, "=", true]]
           schema:
             type: string
             default: "admin"
@@ -46,11 +55,24 @@ questions:
             type: string
             private: true
             default: "changeme"
+            show_if: [[enableWebUI, "=", true]]
             valid_chars: "[a-zA-Z0-9!@#%^&*?]{8,}"
             valid_chars_error: |
               Password must be at least 8 characters long</br>
               Can contain at numbers, letters, and the following characters: !@#%^&*?
             required: true
+        - variable: aliasgroup1
+          label: "Alias Group 1"
+          description: |
+            List of domains that will be allowed to access the Collabora server
+            Type one domain per line
+          schema:
+            type: list
+            items:
+              - variable: alias
+                label: "Alias"
+                schema:
+                  type: string
         - variable: dictionaries
           label: "Dictionaries to use, leave empty to use all"
           schema:
@@ -61,7 +83,7 @@ questions:
           description: 'e.g. "--o:welcome.enable=false", See more on /etc/loolwsd/loowsd.xml. Separate params with space'
           schema:
             type: string
-            default: "--o:welcome.enable=false --o:user_interface.mode=notebookbar --o:ssl.termination=true --o:ssl.enable=false --o:net.proto=IPv4 --o:net.post_allow.host[0]=.+ --o:storage.wopi.host[0]=.+"
+            default: "--o:welcome.enable=false --o:user_interface.mode=notebookbar --o:ssl.termination=true --o:ssl.enable=false --o:net.proto=IPv4"
         - variable: server_name
           label: "Server Name"
           description: |

--- a/library/ix-dev/charts/collabora/templates/deployment.yaml
+++ b/library/ix-dev/charts/collabora/templates/deployment.yaml
@@ -113,7 +113,7 @@ spec:
           {{ $secretName := (include "secretName" .) }}
           {{ $envConfig := .Values.config }}
           {{ $envList = mustAppend $envList (dict "name" "timezone" "value" $envConfig.timezone) }}
-          {{ $envList = mustAppend $envList (dict "name" "aliasgroup1" "value" $envConfig.domain) }}
+          {{ $envList = mustAppend $envList (dict "name" "aliasgroup1" "value" (join "," $envConfig.aliasgroup1)) }}
           {{ $envList = mustAppend $envList (dict "name" "dictionaries" "value" $envConfig.dictionaries) }}
           {{ $envList = mustAppend $envList (dict "name" "extra_params" "value" $envConfig.extra_params) }}
           {{ $envList = mustAppend $envList (dict "name" "DONT_GEN_SSL_CERT" "value" "true") }}
@@ -122,8 +122,10 @@ spec:
           {{ else }}
             {{ $envList = mustAppend $envList (dict "name" "server_name" "value" (printf "%v" $envConfig.server_name)) }}
           {{ end }}
-          {{ $envList = mustAppend $envList (dict "name" "username" "valueFromSecret" true "secretName" $secretName "secretKey" "username") }}
-          {{ $envList = mustAppend $envList (dict "name" "password" "valueFromSecret" true "secretName" $secretName "secretKey" "password") }}
+          {{ if $envConfig.enableWebUI }}
+            {{ $envList = mustAppend $envList (dict "name" "username" "valueFromSecret" true "secretName" $secretName "secretKey" "username") }}
+            {{ $envList = mustAppend $envList (dict "name" "password" "valueFromSecret" true "secretName" $secretName "secretKey" "password") }}
+          {{ end }}
           {{ include "common.containers.allEnvironmentVariables" (dict "environmentVariables" $envList) | nindent 10 }}
       volumes:
         {{ if .Values.certificate }}

--- a/library/ix-dev/charts/collabora/templates/secrets.yaml
+++ b/library/ix-dev/charts/collabora/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{ if or .Values.config.enableWebUI .Values.certificate }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,8 +6,10 @@ metadata:
   labels: {{ include "common.labels" . | nindent 4 }}
 type: Opaque
 data:
+  {{ if .Values.config.enableWebUI }}
   username: {{ .Values.config.username | b64enc | quote }}
   password: {{ .Values.config.password | b64enc | quote }}
+  {{ end }}
   {{ if .Values.certificate }}
     {{ if eq (include "certAvailable" .) "true" }}
   certPublicKey: {{ (include "cert.publicKey" .) | toString | b64enc | quote }}
@@ -15,3 +18,4 @@ data:
       {{ fail "No certificate configured for Collabora" }}
     {{ end }}
   {{ end }}
+{{ end }}


### PR DESCRIPTION
Fixes #1575 
Fixes #1576

When `username` and `password` is not set, the admin panel of collabora is disabled. Introduced a checkbox to toggle the webui
- Caveat is that when it's disabled, we can't also hide the webui portal button

In the above scenario variables of `username` and `password` won't be added, and also the secret won't be created.

---

Exposed to UI the `aliasgroup1` variable (on older collabora versions equivalent variable was `domain`).

From the default extra_params, 
- removed `--o:net.post_allow.host[0]=.+` as by default have all private networks allowed
which is more than enough, considering collabora would be behind nginx if a certificate is selected, or an external reverse proxy if certificate is not selected.

- removed `--o:storage.wopi.host[0]=.+` as it managed by collabora entrypoint script when `aliasgroup1` is configured. beyond that the setting as it is, wasn't working as the correct should be `storage.wopi.group.host[0]` based on the xml structure
