### PR TITLE
Plex_Rollback

### DIFF
--- a/library/ix-dev/charts/plex/values.yaml
+++ b/library/ix-dev/charts/plex/values.yaml
@@ -1,7 +1,7 @@
 image:
   pullPolicy: IfNotPresent
   repository: plexinc/pms-docker
-  tag: 1.32.6.7468-07e0d4a7e
+  tag: 1.32.5.7516-8f4248874
 plexpassImage:
   pullPolicy: IfNotPresent
   repository: plexinc/pms-docker


### PR DESCRIPTION
This change is for Plex latest version that is a rollback in the container version number from [1.32.6.7468-07e0d4a7e] to [1.32.5.7516-8f4248874]. However the app itself is an upgrade from 1.32.5.7349 to 1.32.5.7516.

https://hub.docker.com/r/plexinc/pms-docker/tags
![270867445-aa19d1cb-c942-4698-b695-d66ff758c07e](https://github.com/truenas/charts/assets/53006813/3149a121-f691-4227-b094-31a30343b967)
