### PR TITLE
Use official ghcr.io image for community/immich

### DIFF
--- a/library/ix-dev/community/immich/Chart.yaml
+++ b/library/ix-dev/community/immich/Chart.yaml
@@ -3,7 +3,7 @@ description: Immich
 annotations:
   title: Immich
 type: application
-version: 1.0.26
+version: 1.0.27
 apiVersion: v2
 appVersion: 1.81.1
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/immich/values.yaml
+++ b/library/ix-dev/community/immich/values.yaml
@@ -1,20 +1,20 @@
 image:
-  repository: altran1502/immich-server
+  repository: ghcr.io/immich-app/immich-server
   pullPolicy: IfNotPresent
   tag: v1.81.1
 
 webImage:
-  repository: altran1502/immich-web
+  repository: ghcr.io/immich-app/immich-web
   pullPolicy: IfNotPresent
   tag: v1.81.1
 
 proxyImage:
-  repository: altran1502/immich-proxy
+  repository: ghcr.io/immich-app/immich-proxy
   pullPolicy: IfNotPresent
   tag: v1.81.1
 
 mlImage:
-  repository: altran1502/immich-machine-learning
+  repository: ghcr.io/immich-app/immich-machine-learning
   pullPolicy: IfNotPresent
   tag: v1.81.1
 


### PR DESCRIPTION
Hi !

I'm quite often hit by docker-hub's rate limiting when updating images, especially for immich.

After some investigation, I found that immich is offering their images via ghcr.io Github's Registry.

It seems that it is also what is used in their official docker-compose file https://github.com/immich-app/immich/blob/main/docker/docker-compose.yml

Additionally, the image in docker-hub (under `altran1502`) has the same hash than the one on ghcr.io, so I guess it's just pushed on both registries.