### PR TITLE
Adds smb-pv-pvc option to apps

### DIFF
--- a/library/ix-dev/community/autobrr/Chart.yaml
+++ b/library/ix-dev/community/autobrr/Chart.yaml
@@ -3,7 +3,7 @@ description: Autobrr is the modern download automation tool for torrents and use
 annotations:
   title: Autobrr
 type: application
-version: 1.0.8
+version: 1.1.0
 apiVersion: v2
 appVersion: 1.31.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/autobrr/questions.yaml
+++ b/library/ix-dev/community/autobrr/questions.yaml
@@ -176,6 +176,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -200,6 +202,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/autobrr/questions.yaml
+++ b/library/ix-dev/community/autobrr/questions.yaml
@@ -171,6 +171,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/autobrr/templates/_persistence.tpl
+++ b/library/ix-dev/community/autobrr/templates/_persistence.tpl
@@ -20,10 +20,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.autobrrStorage.additionalStorages }}
   {{ printf "autobrr-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       autobrr:
         autobrr:

--- a/library/ix-dev/community/bazarr/Chart.yaml
+++ b/library/ix-dev/community/bazarr/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
 type: application
 version: 1.0.10
 apiVersion: v2
-appVersion: 1.3.1
+appVersion: 1.4.0
 kubeVersion: '>=1.16.0-0'
 maintainers:
   - name: truenas

--- a/library/ix-dev/community/bazarr/Chart.yaml
+++ b/library/ix-dev/community/bazarr/Chart.yaml
@@ -4,7 +4,7 @@ description: Bazarr is a companion application to Sonarr and Radarr. It manages 
 annotations:
   title: Bazarr
 type: application
-version: 1.0.10
+version: 1.1.0
 apiVersion: v2
 appVersion: 1.4.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/bazarr/questions.yaml
+++ b/library/ix-dev/community/bazarr/questions.yaml
@@ -161,6 +161,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/bazarr/questions.yaml
+++ b/library/ix-dev/community/bazarr/questions.yaml
@@ -166,6 +166,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -190,6 +192,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/bazarr/templates/_persistence.tpl
+++ b/library/ix-dev/community/bazarr/templates/_persistence.tpl
@@ -20,10 +20,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.bazarrStorage.additionalStorages }}
   {{ printf "bazarr-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       bazarr:
         bazarr:

--- a/library/ix-dev/community/briefkasten/Chart.yaml
+++ b/library/ix-dev/community/briefkasten/Chart.yaml
@@ -3,7 +3,7 @@ description: Briefkasten is a self hosted bookmarking app
 annotations:
   title: Briefkasten
 type: application
-version: 1.0.1
+version: 1.1.0
 apiVersion: v2
 appVersion: latest
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/briefkasten/questions.yaml
+++ b/library/ix-dev/community/briefkasten/questions.yaml
@@ -467,6 +467,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/briefkasten/questions.yaml
+++ b/library/ix-dev/community/briefkasten/questions.yaml
@@ -472,6 +472,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -496,6 +498,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/briefkasten/templates/_persistence.tpl
+++ b/library/ix-dev/community/briefkasten/templates/_persistence.tpl
@@ -9,10 +9,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.briefkastenStorage.additionalStorages }}
   {{ printf "briefkasten-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       briefkasten:
         briefkasten:

--- a/library/ix-dev/community/castopod/Chart.yaml
+++ b/library/ix-dev/community/castopod/Chart.yaml
@@ -3,7 +3,7 @@ description: Castopod is an open-source hosting platform made for podcasters who
 annotations:
   title: Castopod
 type: application
-version: 1.0.1
+version: 1.1.0
 apiVersion: v2
 appVersion: 1.6.5
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/castopod/questions.yaml
+++ b/library/ix-dev/community/castopod/questions.yaml
@@ -265,6 +265,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -289,6 +291,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     label: ""

--- a/library/ix-dev/community/castopod/questions.yaml
+++ b/library/ix-dev/community/castopod/questions.yaml
@@ -260,6 +260,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/castopod/templates/_persistance.tpl
+++ b/library/ix-dev/community/castopod/templates/_persistance.tpl
@@ -21,10 +21,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.castopodStorage.additionalStorages }}
   {{ printf "castopod-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       castopod:
         castopod:

--- a/library/ix-dev/community/cloudflared/Chart.yaml
+++ b/library/ix-dev/community/cloudflared/Chart.yaml
@@ -3,7 +3,7 @@ description: Cloudflared is a client for Cloudflare Tunnel, a daemon that expose
 annotations:
   title: Cloudflared
 type: application
-version: 1.0.1
+version: 1.1.0
 apiVersion: v2
 appVersion: 2023.8.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/cloudflared/questions.yaml
+++ b/library/ix-dev/community/cloudflared/questions.yaml
@@ -129,6 +129,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/cloudflared/questions.yaml
+++ b/library/ix-dev/community/cloudflared/questions.yaml
@@ -134,6 +134,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -158,6 +160,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/cloudflared/templates/_persistance.tpl
+++ b/library/ix-dev/community/cloudflared/templates/_persistance.tpl
@@ -2,10 +2,24 @@
 persistence:
   {{- range $idx, $storage := .Values.cloudflaredStorage.additionalStorages }}
   {{ printf "cloudflared-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       cloudflared:
         cloudflared:

--- a/library/ix-dev/community/deluge/Chart.yaml
+++ b/library/ix-dev/community/deluge/Chart.yaml
@@ -3,7 +3,7 @@ description: Deluge is a lightweight, Free Software, cross-platform BitTorrent c
 annotations:
   title: Deluge
 type: application
-version: 1.0.9
+version: 1.1.0
 apiVersion: v2
 appVersion: '9.5.3'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/deluge/questions.yaml
+++ b/library/ix-dev/community/deluge/questions.yaml
@@ -242,6 +242,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/deluge/questions.yaml
+++ b/library/ix-dev/community/deluge/questions.yaml
@@ -247,6 +247,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -271,6 +273,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/deluge/templates/_persistence.tpl
+++ b/library/ix-dev/community/deluge/templates/_persistence.tpl
@@ -22,10 +22,24 @@ persistence:
           mountPath: /downloads
   {{- range $idx, $storage := .Values.delugeStorage.additionalStorages }}
   {{ printf "deluge-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       deluge:
         deluge:

--- a/library/ix-dev/community/distribution/Chart.yaml
+++ b/library/ix-dev/community/distribution/Chart.yaml
@@ -3,7 +3,7 @@ description: Distribution is a toolkit to pack, ship, store, and deliver contain
 annotations:
   title: Distribution
 type: application
-version: 1.0.0
+version: 1.1.0
 apiVersion: v2
 appVersion: 2.8.3
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/distribution/questions.yaml
+++ b/library/ix-dev/community/distribution/questions.yaml
@@ -195,6 +195,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/distribution/questions.yaml
+++ b/library/ix-dev/community/distribution/questions.yaml
@@ -200,6 +200,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -224,6 +226,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/distribution/templates/_persistence.tpl
+++ b/library/ix-dev/community/distribution/templates/_persistence.tpl
@@ -23,10 +23,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.distributionStorage.additionalStorages }}
   {{ printf "distribution-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       distribution:
         distribution:

--- a/library/ix-dev/community/drawio/Chart.yaml
+++ b/library/ix-dev/community/drawio/Chart.yaml
@@ -3,7 +3,7 @@ description: Draw.io is a whiteboarding / diagramming software application.
 annotations:
   title: Draw.IO
 type: application
-version: 1.0.4
+version: 1.1.0
 apiVersion: v2
 appVersion: 22.0.7
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/drawio/questions.yaml
+++ b/library/ix-dev/community/drawio/questions.yaml
@@ -118,6 +118,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -142,6 +144,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/drawio/questions.yaml
+++ b/library/ix-dev/community/drawio/questions.yaml
@@ -113,6 +113,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/drawio/templates/_persistence.tpl
+++ b/library/ix-dev/community/drawio/templates/_persistence.tpl
@@ -9,10 +9,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.drawioStorage.additionalStorages }}
   {{ printf "drawio-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       drawio:
         drawio:

--- a/library/ix-dev/community/filebrowser/Chart.yaml
+++ b/library/ix-dev/community/filebrowser/Chart.yaml
@@ -4,7 +4,7 @@ description: File Browser provides a file managing interface within a specified 
 annotations:
   title: File Browser
 type: application
-version: 1.0.12
+version: 1.1.0
 apiVersion: v2
 appVersion: 2.25.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/filebrowser/questions.yaml
+++ b/library/ix-dev/community/filebrowser/questions.yaml
@@ -173,6 +173,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/filebrowser/questions.yaml
+++ b/library/ix-dev/community/filebrowser/questions.yaml
@@ -178,6 +178,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -202,6 +204,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/filebrowser/templates/_persistence.tpl
+++ b/library/ix-dev/community/filebrowser/templates/_persistence.tpl
@@ -22,10 +22,24 @@ persistence:
       {{- fail (printf "Filebrowser - Expected [Mount Path] to start with [/], but got [%v]" $storage.mountPath) -}}
     {{- end }}
   {{ printf "filebrowser-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       filebrowser:
         filebrowser:

--- a/library/ix-dev/community/flame/Chart.yaml
+++ b/library/ix-dev/community/flame/Chart.yaml
@@ -3,7 +3,7 @@ description: Flame is a self-hosted start page for your server.
 annotations:
   title: Flame
 type: application
-version: 1.0.1
+version: 1.1.0
 apiVersion: v2
 appVersion: 2.3.1
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/flame/questions.yaml
+++ b/library/ix-dev/community/flame/questions.yaml
@@ -151,6 +151,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -175,6 +177,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/flame/questions.yaml
+++ b/library/ix-dev/community/flame/questions.yaml
@@ -146,6 +146,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/flame/templates/_persistence.tpl
+++ b/library/ix-dev/community/flame/templates/_persistence.tpl
@@ -20,10 +20,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.flameStorage.additionalStorages }}
   {{ printf "flame-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       flame:
         flame:

--- a/library/ix-dev/community/frigate/Chart.yaml
+++ b/library/ix-dev/community/frigate/Chart.yaml
@@ -3,7 +3,7 @@ description: Frigate is an NVR With Realtime Object Detection for IP Cameras
 annotations:
   title: Frigate
 type: application
-version: 1.0.2
+version: 1.1.0
 apiVersion: v2
 appVersion: 0.12.1
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/frigate/questions.yaml
+++ b/library/ix-dev/community/frigate/questions.yaml
@@ -275,6 +275,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -299,6 +301,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/frigate/questions.yaml
+++ b/library/ix-dev/community/frigate/questions.yaml
@@ -270,6 +270,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/frigate/templates/_persistence.tpl
+++ b/library/ix-dev/community/frigate/templates/_persistence.tpl
@@ -57,10 +57,24 @@ persistence:
   {{- end -}}
   {{- range $idx, $storage := .Values.frigateStorage.additionalStorages }}
   {{ printf "frigate-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       frigate:
         frigate:

--- a/library/ix-dev/community/fscrawler/Chart.yaml
+++ b/library/ix-dev/community/fscrawler/Chart.yaml
@@ -3,7 +3,7 @@ description: FSCrawler is a crawler that helps to index binary documents such as
 annotations:
   title: FSCrawler
 type: application
-version: 1.0.0
+version: 1.1.0
 apiVersion: v2
 appVersion: '2.9'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/fscrawler/questions.yaml
+++ b/library/ix-dev/community/fscrawler/questions.yaml
@@ -193,6 +193,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/fscrawler/questions.yaml
+++ b/library/ix-dev/community/fscrawler/questions.yaml
@@ -198,6 +198,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -222,6 +224,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/fscrawler/templates/_persistence.tpl
+++ b/library/ix-dev/community/fscrawler/templates/_persistence.tpl
@@ -22,10 +22,24 @@ persistence:
           subPath: _settings.example.yaml
   {{- range $idx, $storage := .Values.fscrawlerStorage.additionalStorages }}
   {{ printf "fscrawler-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       fscrawler:
         fscrawler:

--- a/library/ix-dev/community/grafana/Chart.yaml
+++ b/library/ix-dev/community/grafana/Chart.yaml
@@ -4,7 +4,7 @@ description: Grafana is the open source analytics & monitoring solution for ever
 annotations:
   title: Grafana
 type: application
-version: 1.0.18
+version: 1.1.0
 apiVersion: v2
 appVersion: 10.2.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/grafana/questions.yaml
+++ b/library/ix-dev/community/grafana/questions.yaml
@@ -202,6 +202,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -226,6 +228,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/grafana/questions.yaml
+++ b/library/ix-dev/community/grafana/questions.yaml
@@ -197,6 +197,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/grafana/templates/_grafana.tpl
+++ b/library/ix-dev/community/grafana/templates/_grafana.tpl
@@ -88,10 +88,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.grafanaStorage.additionalStorages }}
   {{ printf "grafana-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       grafana:
         grafana:

--- a/library/ix-dev/community/homarr/Chart.yaml
+++ b/library/ix-dev/community/homarr/Chart.yaml
@@ -4,7 +4,7 @@ description: Homarr is a sleek, modern dashboard that puts all of your apps and 
 annotations:
   title: Homarr
 type: application
-version: 1.0.5
+version: 1.1.0
 apiVersion: v2
 appVersion: 0.13.4
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/homarr/questions.yaml
+++ b/library/ix-dev/community/homarr/questions.yaml
@@ -216,6 +216,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/homarr/questions.yaml
+++ b/library/ix-dev/community/homarr/questions.yaml
@@ -221,6 +221,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -245,6 +247,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/homarr/templates/_persistence.tpl
+++ b/library/ix-dev/community/homarr/templates/_persistence.tpl
@@ -31,10 +31,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.homarrStorage.additionalStorages }}
   {{ printf "homarr-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       homarr:
         homarr:

--- a/library/ix-dev/community/homepage/Chart.yaml
+++ b/library/ix-dev/community/homepage/Chart.yaml
@@ -3,7 +3,7 @@ description: Homepage is a modern, secure, highly customizable application dashb
 annotations:
   title: Homepage
 type: application
-version: 1.0.13
+version: 1.1.0
 apiVersion: v2
 appVersion: 0.7.1
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/homepage/questions.yaml
+++ b/library/ix-dev/community/homepage/questions.yaml
@@ -141,6 +141,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -165,6 +167,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/homepage/questions.yaml
+++ b/library/ix-dev/community/homepage/questions.yaml
@@ -136,6 +136,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/homepage/templates/_persistence.tpl
+++ b/library/ix-dev/community/homepage/templates/_persistence.tpl
@@ -20,10 +20,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.homepageStorage.additionalStorages }}
   {{ printf "homepage-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       homepage:
         homepage:

--- a/library/ix-dev/community/homer/Chart.yaml
+++ b/library/ix-dev/community/homer/Chart.yaml
@@ -4,7 +4,7 @@ description: Homer is a dead simple static HOMepage for your servER to keep your
 annotations:
   title: Homer
 type: application
-version: 1.0.2
+version: 1.1.0
 apiVersion: v2
 appVersion: 23.10.1
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/homer/questions.yaml
+++ b/library/ix-dev/community/homer/questions.yaml
@@ -167,6 +167,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/homer/questions.yaml
+++ b/library/ix-dev/community/homer/questions.yaml
@@ -172,6 +172,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -196,6 +198,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/homer/templates/_persistence.tpl
+++ b/library/ix-dev/community/homer/templates/_persistence.tpl
@@ -20,10 +20,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.homerStorage.additionalStorages }}
   {{ printf "homer-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       homer:
         homer:

--- a/library/ix-dev/community/jellyfin/Chart.yaml
+++ b/library/ix-dev/community/jellyfin/Chart.yaml
@@ -4,7 +4,7 @@ description: Jellyfin is a Free Software Media System that puts you in control o
 annotations:
   title: Jellyfin
 type: application
-version: 1.0.15
+version: 1.1.10
 apiVersion: v2
 appVersion: 10.8.11
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/jellyfin/Chart.yaml
+++ b/library/ix-dev/community/jellyfin/Chart.yaml
@@ -4,7 +4,7 @@ description: Jellyfin is a Free Software Media System that puts you in control o
 annotations:
   title: Jellyfin
 type: application
-version: 1.1.10
+version: 1.1.0
 apiVersion: v2
 appVersion: 10.8.11
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/jellyfin/questions.yaml
+++ b/library/ix-dev/community/jellyfin/questions.yaml
@@ -272,6 +272,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/jellyfin/questions.yaml
+++ b/library/ix-dev/community/jellyfin/questions.yaml
@@ -277,6 +277,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -301,6 +303,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/jellyfin/templates/_jellyfin.tpl
+++ b/library/ix-dev/community/jellyfin/templates/_jellyfin.tpl
@@ -113,10 +113,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.jellyfinStorage.additionalStorages }}
   {{ printf "jellyfin-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       jellyfin:
         jellyfin:

--- a/library/ix-dev/community/jenkins/Chart.yaml
+++ b/library/ix-dev/community/jenkins/Chart.yaml
@@ -3,7 +3,7 @@ description: Jenkins is a leading open source automation server,
 annotations:
   title: Jenkins
 type: application
-version: 1.0.14
+version: 1.1.0
 apiVersion: v2
 appVersion: 2.414.3
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/jenkins/questions.yaml
+++ b/library/ix-dev/community/jenkins/questions.yaml
@@ -219,6 +219,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/jenkins/questions.yaml
+++ b/library/ix-dev/community/jenkins/questions.yaml
@@ -224,6 +224,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -248,6 +250,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/jenkins/templates/_jenkins.tpl
+++ b/library/ix-dev/community/jenkins/templates/_jenkins.tpl
@@ -112,10 +112,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.jenkinsStorage.additionalStorages }}
   {{ printf "jenkins-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       jenkins:
         jenkins:

--- a/library/ix-dev/community/kapowarr/Chart.yaml
+++ b/library/ix-dev/community/kapowarr/Chart.yaml
@@ -3,7 +3,7 @@ description: Kapowarr is a software to build and manage a comic book library, fi
 annotations:
   title: Kapowarr
 type: application
-version: 1.0.1
+version: 1.1.0
 apiVersion: v2
 appVersion: 1.0.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/kapowarr/questions.yaml
+++ b/library/ix-dev/community/kapowarr/questions.yaml
@@ -237,6 +237,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/kapowarr/questions.yaml
+++ b/library/ix-dev/community/kapowarr/questions.yaml
@@ -242,6 +242,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -266,6 +268,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/kapowarr/templates/_persistence.tpl
+++ b/library/ix-dev/community/kapowarr/templates/_persistence.tpl
@@ -35,10 +35,24 @@ persistence:
           mountPath: /mnt/directories/content
   {{- range $idx, $storage := .Values.kapowarrStorage.additionalStorages }}
   {{ printf "kapowarr-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       kapowarr:
         kapowarr:

--- a/library/ix-dev/community/kavita/Chart.yaml
+++ b/library/ix-dev/community/kavita/Chart.yaml
@@ -3,7 +3,7 @@ description: Kavita is a fast, feature rich, cross platform reading server.
 annotations:
   title: Kavita
 type: application
-version: 1.0.1
+version: 1.1.0
 apiVersion: v2
 appVersion: 0.7.8
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/kavita/questions.yaml
+++ b/library/ix-dev/community/kavita/questions.yaml
@@ -145,6 +145,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -169,6 +171,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/kavita/questions.yaml
+++ b/library/ix-dev/community/kavita/questions.yaml
@@ -140,6 +140,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/kavita/templates/_persistence.tpl
+++ b/library/ix-dev/community/kavita/templates/_persistence.tpl
@@ -12,10 +12,24 @@ persistence:
 
   {{- range $idx, $storage := .Values.kavitaStorage.additionalStorages }}
   {{ printf "kavita-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       kavita:
         kavita:

--- a/library/ix-dev/community/komga/Chart.yaml
+++ b/library/ix-dev/community/komga/Chart.yaml
@@ -3,7 +3,7 @@ description: Komga is a free and open source comics/mangas server.
 annotations:
   title: Komga
 type: application
-version: 1.0.15
+version: 1.1.0
 apiVersion: v2
 appVersion: 1.6.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/komga/questions.yaml
+++ b/library/ix-dev/community/komga/questions.yaml
@@ -176,6 +176,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -200,6 +202,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/komga/questions.yaml
+++ b/library/ix-dev/community/komga/questions.yaml
@@ -171,6 +171,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/komga/templates/_persistence.tpl
+++ b/library/ix-dev/community/komga/templates/_persistence.tpl
@@ -20,10 +20,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.komgaStorage.additionalStorages }}
   {{ printf "komga-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       komga:
         komga:

--- a/library/ix-dev/community/lidarr/Chart.yaml
+++ b/library/ix-dev/community/lidarr/Chart.yaml
@@ -3,7 +3,7 @@ description: Lidarr is a music collection manager for Usenet and BitTorrent user
 annotations:
   title: Lidarr
 type: application
-version: 1.0.25
+version: 1.1.0
 apiVersion: v2
 appVersion: 1.4.5.3639
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/lidarr/questions.yaml
+++ b/library/ix-dev/community/lidarr/questions.yaml
@@ -168,6 +168,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/lidarr/questions.yaml
+++ b/library/ix-dev/community/lidarr/questions.yaml
@@ -173,6 +173,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -197,6 +199,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/lidarr/templates/_lidarr.tpl
+++ b/library/ix-dev/community/lidarr/templates/_lidarr.tpl
@@ -84,10 +84,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.lidarrStorage.additionalStorages }}
   {{ printf "lidarr-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       lidarr:
         lidarr:

--- a/library/ix-dev/community/linkding/Chart.yaml
+++ b/library/ix-dev/community/linkding/Chart.yaml
@@ -3,7 +3,7 @@ description: Linkding is a bookmark manager that you can host yourself.
 annotations:
   title: Linkding
 type: application
-version: 1.0.3
+version: 1.1.0
 apiVersion: v2
 appVersion: 1.22.1
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/linkding/questions.yaml
+++ b/library/ix-dev/community/linkding/questions.yaml
@@ -320,6 +320,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -344,6 +346,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/linkding/questions.yaml
+++ b/library/ix-dev/community/linkding/questions.yaml
@@ -315,6 +315,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/linkding/templates/_persistence.tpl
+++ b/library/ix-dev/community/linkding/templates/_persistence.tpl
@@ -30,10 +30,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.linkdingStorage.additionalStorages }}
   {{ printf "linkding-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       linkding:
         linkding:

--- a/library/ix-dev/community/listmonk/Chart.yaml
+++ b/library/ix-dev/community/listmonk/Chart.yaml
@@ -3,7 +3,7 @@ description: Listmonk is a self-hosted newsletter and mailing list manager.
 annotations:
   title: Listmonk
 type: application
-version: 1.0.1
+version: 1.1.0
 apiVersion: v2
 appVersion: v2.5.1
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/listmonk/questions.yaml
+++ b/library/ix-dev/community/listmonk/questions.yaml
@@ -253,6 +253,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/listmonk/questions.yaml
+++ b/library/ix-dev/community/listmonk/questions.yaml
@@ -258,6 +258,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -282,6 +284,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/listmonk/templates/_persistence.tpl
+++ b/library/ix-dev/community/listmonk/templates/_persistence.tpl
@@ -20,10 +20,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.listmonkStorage.additionalStorages }}
   {{ printf "listmonk-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       listmonk:
         listmonk:

--- a/library/ix-dev/community/logseq/Chart.yaml
+++ b/library/ix-dev/community/logseq/Chart.yaml
@@ -3,7 +3,7 @@ description: Logseq is a privacy-first, open-source platform for knowledge manag
 annotations:
   title: Logseq
 type: application
-version: 1.0.1
+version: 1.1.0
 apiVersion: v2
 appVersion: latest
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/logseq/questions.yaml
+++ b/library/ix-dev/community/logseq/questions.yaml
@@ -136,6 +136,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -160,6 +162,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/logseq/questions.yaml
+++ b/library/ix-dev/community/logseq/questions.yaml
@@ -131,6 +131,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/logseq/templates/_persistence.tpl
+++ b/library/ix-dev/community/logseq/templates/_persistence.tpl
@@ -34,10 +34,24 @@ persistence:
           mountPath: /var/run
   {{- range $idx, $storage := .Values.logseqStorage.additionalStorages }}
   {{ printf "logseq-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       logseq:
         logseq:

--- a/library/ix-dev/community/metube/Chart.yaml
+++ b/library/ix-dev/community/metube/Chart.yaml
@@ -4,7 +4,7 @@ description: MeTube is a web GUI for youtube-dl (using the yt-dlp fork) with pla
 annotations:
   title: MeTube
 type: application
-version: 1.0.5
+version: 1.1.0
 apiVersion: v2
 appVersion: '2023-10-20'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/metube/questions.yaml
+++ b/library/ix-dev/community/metube/questions.yaml
@@ -175,6 +175,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/metube/questions.yaml
+++ b/library/ix-dev/community/metube/questions.yaml
@@ -180,6 +180,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -204,6 +206,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/metube/templates/_persistence.tpl
+++ b/library/ix-dev/community/metube/templates/_persistence.tpl
@@ -20,10 +20,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.metubeStorage.additionalStorages }}
   {{ printf "metube-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       metube:
         metube:

--- a/library/ix-dev/community/minecraft/Chart.yaml
+++ b/library/ix-dev/community/minecraft/Chart.yaml
@@ -3,7 +3,7 @@ description: Minecraft is a sandbox game
 annotations:
   title: Minecraft
 type: application
-version: 1.0.17
+version: 1.1.0
 apiVersion: v2
 appVersion: 2023.10.1
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/minecraft/questions.yaml
+++ b/library/ix-dev/community/minecraft/questions.yaml
@@ -581,6 +581,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/minecraft/questions.yaml
+++ b/library/ix-dev/community/minecraft/questions.yaml
@@ -586,6 +586,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -610,6 +612,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/minecraft/templates/_minecraft.tpl
+++ b/library/ix-dev/community/minecraft/templates/_minecraft.tpl
@@ -86,10 +86,24 @@ persistence:
           mountPath: /data
   {{- range $idx, $storage := .Values.mcStorage.additionalStorages }}
   {{ printf "mc-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       minecraft:
         minecraft:

--- a/library/ix-dev/community/n8n/Chart.yaml
+++ b/library/ix-dev/community/n8n/Chart.yaml
@@ -3,7 +3,7 @@ description: n8n is an extendable workflow automation tool.
 annotations:
   title: n8n
 type: application
-version: 1.0.14
+version: 1.1.0
 apiVersion: v2
 appVersion: 1.12.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/n8n/questions.yaml
+++ b/library/ix-dev/community/n8n/questions.yaml
@@ -238,6 +238,102 @@ questions:
                   show_if: [["type", "=", "hostPath"]]
                   immutable: true
                   required: true
+        - variable: additionalStorages
+          label: Additional Storage
+          description: Additional storage for n8n.
+          schema:
+            type: list
+            default: []
+            items:
+              - variable: storageEntry
+                label: Storage Entry
+                schema:
+                  type: dict
+                  attrs:
+                    - variable: type
+                      label: Type
+                      description: |
+                        ixVolume: Is dataset created automatically by the system.</br>
+                        Host Path: Is a path that already exists on the system.
+                      schema:
+                        type: string
+                        required: true
+                        default: "ixVolume"
+                        enum:
+                          - value: "hostPath"
+                            description: Host Path (Path that already exists on the system)
+                          - value: "ixVolume"
+                            description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
+                    - variable: mountPath
+                      label: Mount Path
+                      description: The path inside the container to mount the storage.
+                      schema:
+                        type: path
+                        required: true
+                    - variable: hostPath
+                      label: Host Path
+                      description: The host path to use for storage.
+                      schema:
+                        type: hostpath
+                        show_if: [["type", "=", "hostPath"]]
+                        required: true
+                    - variable: datasetName
+                      label: Dataset Name
+                      description: The name of the dataset to use for storage.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "ixVolume"]]
+                        required: true
+                        immutable: true
+                        default: "storage_entry"
+                        $ref:
+                          - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     label: ""

--- a/library/ix-dev/community/n8n/questions.yaml
+++ b/library/ix-dev/community/n8n/questions.yaml
@@ -259,6 +259,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/n8n/templates/_persistence.tpl
+++ b/library/ix-dev/community/n8n/templates/_persistence.tpl
@@ -20,10 +20,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.n8nStorage.additionalStorages }}
   {{ printf "n8n-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       n8n:
         n8n:

--- a/library/ix-dev/community/navidrome/Chart.yaml
+++ b/library/ix-dev/community/navidrome/Chart.yaml
@@ -3,7 +3,7 @@ description: Navidrome is a personal streaming service
 annotations:
   title: Navidrome
 type: application
-version: 1.0.7
+version: 1.1.0
 apiVersion: v2
 appVersion: '0.49.3'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/navidrome/questions.yaml
+++ b/library/ix-dev/community/navidrome/questions.yaml
@@ -205,6 +205,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/navidrome/questions.yaml
+++ b/library/ix-dev/community/navidrome/questions.yaml
@@ -210,6 +210,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -234,6 +236,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/navidrome/templates/_persistence.tpl
+++ b/library/ix-dev/community/navidrome/templates/_persistence.tpl
@@ -24,10 +24,24 @@ persistence:
           mountPath: /mnt/directories/music
   {{- range $idx, $storage := .Values.navidromeStorage.additionalStorages }}
   {{ printf "navidrome-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       navidrome:
         navidrome:

--- a/library/ix-dev/community/node-red/Chart.yaml
+++ b/library/ix-dev/community/node-red/Chart.yaml
@@ -4,7 +4,7 @@ description: Node-RED is a programming tool for wiring together hardware devices
 annotations:
   title: Node-RED
 type: application
-version: 1.0.5
+version: 1.1.0
 apiVersion: v2
 appVersion: 3.1.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/node-red/questions.yaml
+++ b/library/ix-dev/community/node-red/questions.yaml
@@ -176,6 +176,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/node-red/questions.yaml
+++ b/library/ix-dev/community/node-red/questions.yaml
@@ -181,6 +181,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -205,6 +207,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/node-red/templates/_persistence.tpl
+++ b/library/ix-dev/community/node-red/templates/_persistence.tpl
@@ -20,10 +20,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.noderedStorage.additionalStorages }}
   {{ printf "nodered-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       nodered:
         nodered:

--- a/library/ix-dev/community/omada-controller/Chart.yaml
+++ b/library/ix-dev/community/omada-controller/Chart.yaml
@@ -4,7 +4,7 @@ description: Omada Controller (TP-Link) is a network management controller for T
 annotations:
   title: Omada Controller
 type: application
-version: 1.0.2
+version: 1.1.0
 apiVersion: v2
 appVersion: '5.12'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/omada-controller/questions.yaml
+++ b/library/ix-dev/community/omada-controller/questions.yaml
@@ -299,6 +299,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/omada-controller/questions.yaml
+++ b/library/ix-dev/community/omada-controller/questions.yaml
@@ -304,6 +304,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -328,6 +330,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/omada-controller/templates/_persistence.tpl
+++ b/library/ix-dev/community/omada-controller/templates/_persistence.tpl
@@ -31,10 +31,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.omadaStorage.additionalStorages }}
   {{ printf "omada-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       omada:
         omada:

--- a/library/ix-dev/community/paperless-ngx/Chart.yaml
+++ b/library/ix-dev/community/paperless-ngx/Chart.yaml
@@ -3,7 +3,7 @@ description: Paperless-ngx is a document management system that transforms your 
 annotations:
   title: Paperless-ngx
 type: application
-version: 1.0.1
+version: 1.1.0
 apiVersion: v2
 appVersion: 1.17.4
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/paperless-ngx/questions.yaml
+++ b/library/ix-dev/community/paperless-ngx/questions.yaml
@@ -409,6 +409,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -433,6 +435,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/paperless-ngx/questions.yaml
+++ b/library/ix-dev/community/paperless-ngx/questions.yaml
@@ -404,6 +404,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/paperless-ngx/templates/_persistence.tpl
+++ b/library/ix-dev/community/paperless-ngx/templates/_persistence.tpl
@@ -47,10 +47,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.paperlessStorage.additionalStorages }}
   {{ printf "paperless-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       paperless:
         paperless:

--- a/library/ix-dev/community/passbolt/Chart.yaml
+++ b/library/ix-dev/community/passbolt/Chart.yaml
@@ -3,7 +3,7 @@ description: Passbolt is a security-first, open source password manager
 annotations:
   title: Passbolt
 type: application
-version: 1.0.0
+version: 1.1.0
 apiVersion: v2
 appVersion: 4.3.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/passbolt/questions.yaml
+++ b/library/ix-dev/community/passbolt/questions.yaml
@@ -268,6 +268,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/passbolt/questions.yaml
+++ b/library/ix-dev/community/passbolt/questions.yaml
@@ -273,6 +273,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -297,6 +299,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     label: ""

--- a/library/ix-dev/community/passbolt/templates/_persistence.tpl
+++ b/library/ix-dev/community/passbolt/templates/_persistence.tpl
@@ -38,10 +38,24 @@ persistence:
           mountPath: /var/run
   {{- range $idx, $storage := .Values.passboltStorage.additionalStorages }}
   {{ printf "passbolt-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       passbolt:
         passbolt:

--- a/library/ix-dev/community/pgadmin/Chart.yaml
+++ b/library/ix-dev/community/pgadmin/Chart.yaml
@@ -4,7 +4,7 @@ description: pgAdmin is the most popular and feature rich Open Source administra
 annotations:
   title: pgAdmin
 type: application
-version: 1.0.5
+version: 1.1.0
 apiVersion: v2
 appVersion: '7.8'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/pgadmin/questions.yaml
+++ b/library/ix-dev/community/pgadmin/questions.yaml
@@ -164,6 +164,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -188,6 +190,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/pgadmin/questions.yaml
+++ b/library/ix-dev/community/pgadmin/questions.yaml
@@ -159,6 +159,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/pgadmin/templates/_persistence.tpl
+++ b/library/ix-dev/community/pgadmin/templates/_persistence.tpl
@@ -20,10 +20,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.pgadminStorage.additionalStorages }}
   {{ printf "pgadmin-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       pgadmin:
         pgadmin:

--- a/library/ix-dev/community/pigallery2/Chart.yaml
+++ b/library/ix-dev/community/pigallery2/Chart.yaml
@@ -3,7 +3,7 @@ description: PiGallery2 is a fast directory-first photo gallery website, with ri
 annotations:
   title: PiGallery2
 type: application
-version: 1.0.0
+version: 1.1.0
 apiVersion: v2
 appVersion: 2.0.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/pigallery2/questions.yaml
+++ b/library/ix-dev/community/pigallery2/questions.yaml
@@ -287,6 +287,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -311,6 +313,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/pigallery2/questions.yaml
+++ b/library/ix-dev/community/pigallery2/questions.yaml
@@ -282,6 +282,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/pigallery2/templates/_persistence.tpl
+++ b/library/ix-dev/community/pigallery2/templates/_persistence.tpl
@@ -46,10 +46,24 @@ persistence:
           mountPath: /mnt/directories/thumbnails
   {{- range $idx, $storage := .Values.pigalleryStorage.additionalStorages }}
   {{ printf "pigallery-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       pigallery:
         pigallery:

--- a/library/ix-dev/community/piwigo/Chart.yaml
+++ b/library/ix-dev/community/piwigo/Chart.yaml
@@ -3,7 +3,7 @@ description: Piwigo is a photo gallery software for the web that comes with powe
 annotations:
   title: Piwigo
 type: application
-version: 1.0.1
+version: 1.1.0
 apiVersion: v2
 appVersion: 13.8.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/piwigo/questions.yaml
+++ b/library/ix-dev/community/piwigo/questions.yaml
@@ -454,6 +454,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/piwigo/questions.yaml
+++ b/library/ix-dev/community/piwigo/questions.yaml
@@ -459,6 +459,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -483,6 +485,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     label: ""

--- a/library/ix-dev/community/piwigo/templates/_persistance.tpl
+++ b/library/ix-dev/community/piwigo/templates/_persistance.tpl
@@ -27,10 +27,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.piwiStorage.additionalStorages }}
   {{ printf "piwi-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       piwigo:
         piwigo:

--- a/library/ix-dev/community/planka/Chart.yaml
+++ b/library/ix-dev/community/planka/Chart.yaml
@@ -3,7 +3,7 @@ description: Planka is an Elegant open source project tracking
 annotations:
   title: Planka
 type: application
-version: 1.0.6
+version: 1.1.0
 apiVersion: v2
 appVersion: 1.14.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/planka/questions.yaml
+++ b/library/ix-dev/community/planka/questions.yaml
@@ -340,6 +340,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -364,6 +366,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/planka/questions.yaml
+++ b/library/ix-dev/community/planka/questions.yaml
@@ -335,6 +335,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/planka/templates/_persistence.tpl
+++ b/library/ix-dev/community/planka/templates/_persistence.tpl
@@ -42,10 +42,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.plankaStorage.additionalStorages }}
   {{ printf "planka-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       planka:
         planka:

--- a/library/ix-dev/community/plex-auto-languages/Chart.yaml
+++ b/library/ix-dev/community/plex-auto-languages/Chart.yaml
@@ -3,7 +3,7 @@ description: Plex Auto Languages offer automated language selection for Plex TV 
 annotations:
   title: Plex Auto Languages
 type: application
-version: 1.0.3
+version: 1.1.0
 apiVersion: v2
 appVersion: 1.2.3
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/plex-auto-languages/questions.yaml
+++ b/library/ix-dev/community/plex-auto-languages/questions.yaml
@@ -151,6 +151,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/plex-auto-languages/questions.yaml
+++ b/library/ix-dev/community/plex-auto-languages/questions.yaml
@@ -156,6 +156,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -180,6 +182,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/plex-auto-languages/templates/_persistence.tpl
+++ b/library/ix-dev/community/plex-auto-languages/templates/_persistence.tpl
@@ -20,10 +20,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.palStorage.additionalStorages }}
   {{ printf "pal-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       pal:
         pal:

--- a/library/ix-dev/community/prowlarr/Chart.yaml
+++ b/library/ix-dev/community/prowlarr/Chart.yaml
@@ -4,7 +4,7 @@ description: Prowlarr is an indexer manager/proxy to integrate with your various
 annotations:
   title: Prowlarr
 type: application
-version: 1.0.18
+version: 1.1.0
 apiVersion: v2
 appVersion: 1.10.0.4047
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/prowlarr/questions.yaml
+++ b/library/ix-dev/community/prowlarr/questions.yaml
@@ -168,6 +168,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/prowlarr/questions.yaml
+++ b/library/ix-dev/community/prowlarr/questions.yaml
@@ -173,6 +173,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -197,6 +199,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/prowlarr/templates/_persistence.tpl
+++ b/library/ix-dev/community/prowlarr/templates/_persistence.tpl
@@ -20,10 +20,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.prowlarrStorage.additionalStorages }}
   {{ printf "prowlarr-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       prowlarr:
         prowlarr:

--- a/library/ix-dev/community/qbittorrent/Chart.yaml
+++ b/library/ix-dev/community/qbittorrent/Chart.yaml
@@ -4,7 +4,7 @@ description: The qBittorrent project aims to provide an open-source software alt
 annotations:
   title: qBittorrent
 type: application
-version: 1.0.24
+version: 1.1.0
 apiVersion: v2
 appVersion: 4.6.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/qbittorrent/questions.yaml
+++ b/library/ix-dev/community/qbittorrent/questions.yaml
@@ -213,6 +213,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -237,6 +239,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     label: Resources Configuration

--- a/library/ix-dev/community/qbittorrent/questions.yaml
+++ b/library/ix-dev/community/qbittorrent/questions.yaml
@@ -208,6 +208,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/qbittorrent/templates/_qbittorrent.tpl
+++ b/library/ix-dev/community/qbittorrent/templates/_qbittorrent.tpl
@@ -106,10 +106,24 @@ persistence:
           mountPath: /mnt/directories/downloads
   {{- range $idx, $storage := .Values.qbitStorage.additionalStorages }}
   {{ printf "qbittorrent-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       qbittorrent:
         qbittorrent:

--- a/library/ix-dev/community/radarr/Chart.yaml
+++ b/library/ix-dev/community/radarr/Chart.yaml
@@ -3,7 +3,7 @@ description: Radarr is a movie collection manager for Usenet and BitTorrent user
 annotations:
   title: Radarr
 type: application
-version: 1.0.23
+version: 1.1.0
 apiVersion: v2
 appVersion: 5.0.3.8127
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/radarr/questions.yaml
+++ b/library/ix-dev/community/radarr/questions.yaml
@@ -168,6 +168,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/radarr/questions.yaml
+++ b/library/ix-dev/community/radarr/questions.yaml
@@ -173,6 +173,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -197,6 +199,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/radarr/templates/_radarr.tpl
+++ b/library/ix-dev/community/radarr/templates/_radarr.tpl
@@ -84,10 +84,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.radarrStorage.additionalStorages }}
   {{ printf "radarr-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       radarr:
         radarr:

--- a/library/ix-dev/community/readarr/Chart.yaml
+++ b/library/ix-dev/community/readarr/Chart.yaml
@@ -4,7 +4,7 @@ description: Readarr is an ebook and audiobook collection manager for Usenet and
 annotations:
   title: Readarr
 type: application
-version: 1.0.16
+version: 1.1.0
 apiVersion: v2
 appVersion: 0.3.8.2267
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/readarr/questions.yaml
+++ b/library/ix-dev/community/readarr/questions.yaml
@@ -168,6 +168,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/readarr/questions.yaml
+++ b/library/ix-dev/community/readarr/questions.yaml
@@ -173,6 +173,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -197,6 +199,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/readarr/templates/_persistence.tpl
+++ b/library/ix-dev/community/readarr/templates/_persistence.tpl
@@ -20,10 +20,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.readarrStorage.additionalStorages }}
   {{ printf "readarr-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       readarr:
         readarr:

--- a/library/ix-dev/community/recyclarr/Chart.yaml
+++ b/library/ix-dev/community/recyclarr/Chart.yaml
@@ -4,7 +4,7 @@ description: Recyclarr synchronizes recommended settings from the TRaSH guides t
 annotations:
   title: Recyclarr
 type: application
-version: 1.0.12
+version: 1.1.0
 apiVersion: v2
 appVersion: 6.0.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/recyclarr/questions.yaml
+++ b/library/ix-dev/community/recyclarr/questions.yaml
@@ -153,6 +153,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/recyclarr/questions.yaml
+++ b/library/ix-dev/community/recyclarr/questions.yaml
@@ -158,6 +158,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -182,6 +184,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/recyclarr/templates/_persistence.tpl
+++ b/library/ix-dev/community/recyclarr/templates/_persistence.tpl
@@ -20,10 +20,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.recyclarrStorage.additionalStorages }}
   {{ printf "recyclarr-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       recyclarr:
         recyclarr:

--- a/library/ix-dev/community/rust-desk/Chart.yaml
+++ b/library/ix-dev/community/rust-desk/Chart.yaml
@@ -3,7 +3,7 @@ description: Rust Desk is an open-source remote desktop, and alternative to Team
 annotations:
   title: Rust Desk
 type: application
-version: 1.0.1
+version: 1.1.0
 apiVersion: v2
 appVersion: '1.1.8-2'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/rust-desk/questions.yaml
+++ b/library/ix-dev/community/rust-desk/questions.yaml
@@ -235,6 +235,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -259,6 +261,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/rust-desk/questions.yaml
+++ b/library/ix-dev/community/rust-desk/questions.yaml
@@ -230,6 +230,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/rust-desk/templates/_persistence.tpl
+++ b/library/ix-dev/community/rust-desk/templates/_persistence.tpl
@@ -16,10 +16,24 @@ persistence:
           mountPath: /root
   {{- range $idx, $storage := .Values.rustStorage.additionalStorages }}
   {{ printf "rust-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       server:
         server:

--- a/library/ix-dev/community/sabnzbd/Chart.yaml
+++ b/library/ix-dev/community/sabnzbd/Chart.yaml
@@ -3,7 +3,7 @@ description: SABnzbd is an Open Source Binary Newsreader written in Python.
 annotations:
   title: SABnzbd
 type: application
-version: 1.0.4
+version: 1.1.0
 apiVersion: v2
 appVersion: 4.1.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/sabnzbd/questions.yaml
+++ b/library/ix-dev/community/sabnzbd/questions.yaml
@@ -161,6 +161,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/sabnzbd/questions.yaml
+++ b/library/ix-dev/community/sabnzbd/questions.yaml
@@ -166,6 +166,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -190,6 +192,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/sabnzbd/templates/_persistence.tpl
+++ b/library/ix-dev/community/sabnzbd/templates/_persistence.tpl
@@ -20,10 +20,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.sabnzbdStorage.additionalStorages }}
   {{ printf "sabnzbd-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       sabnzbd:
         sabnzbd:

--- a/library/ix-dev/community/searxng/Chart.yaml
+++ b/library/ix-dev/community/searxng/Chart.yaml
@@ -3,7 +3,7 @@ description: SearXNG is a privacy-respecting, hackable metasearch engine
 annotations:
   title: SearXNG
 type: application
-version: 1.0.8
+version: 1.1.0
 apiVersion: v2
 appVersion: 2023.10.22
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/searxng/questions.yaml
+++ b/library/ix-dev/community/searxng/questions.yaml
@@ -148,6 +148,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -172,6 +174,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/searxng/questions.yaml
+++ b/library/ix-dev/community/searxng/questions.yaml
@@ -143,6 +143,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/searxng/templates/_persistence.tpl
+++ b/library/ix-dev/community/searxng/templates/_persistence.tpl
@@ -20,10 +20,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.searxngStorage.additionalStorages }}
   {{ printf "searxng-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       searxng:
         searxng:

--- a/library/ix-dev/community/sftpgo/Chart.yaml
+++ b/library/ix-dev/community/sftpgo/Chart.yaml
@@ -3,7 +3,7 @@ description: SFTPGo is a fully featured and highly configurable SFTP server with
 annotations:
   title: SFTPGo
 type: application
-version: 1.0.1
+version: 1.1.0
 apiVersion: v2
 appVersion: v2.5.4
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/sftpgo/questions.yaml
+++ b/library/ix-dev/community/sftpgo/questions.yaml
@@ -376,6 +376,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -400,6 +402,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/sftpgo/questions.yaml
+++ b/library/ix-dev/community/sftpgo/questions.yaml
@@ -371,6 +371,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/sftpgo/templates/_persistence.tpl
+++ b/library/ix-dev/community/sftpgo/templates/_persistence.tpl
@@ -42,10 +42,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.sftpgoStorage.additionalStorages }}
   {{ printf "sftpgo-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       sftpgo:
         sftpgo:

--- a/library/ix-dev/community/sonarr/Chart.yaml
+++ b/library/ix-dev/community/sonarr/Chart.yaml
@@ -3,7 +3,7 @@ description: Sonarr is a PVR for Usenet and BitTorrent users.
 annotations:
   title: Sonarr
 type: application
-version: 1.0.17
+version: 1.1.0
 apiVersion: v2
 appVersion: '3.0.10.1567'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/sonarr/questions.yaml
+++ b/library/ix-dev/community/sonarr/questions.yaml
@@ -168,6 +168,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/sonarr/questions.yaml
+++ b/library/ix-dev/community/sonarr/questions.yaml
@@ -173,6 +173,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -197,6 +199,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/sonarr/templates/_sonarr.tpl
+++ b/library/ix-dev/community/sonarr/templates/_sonarr.tpl
@@ -84,10 +84,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.sonarrStorage.additionalStorages }}
   {{ printf "sonarr-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       sonarr:
         sonarr:

--- a/library/ix-dev/community/tautulli/Chart.yaml
+++ b/library/ix-dev/community/tautulli/Chart.yaml
@@ -3,7 +3,7 @@ description: Tautulli is a python based web application for monitoring, analytic
 annotations:
   title: Tautulli
 type: application
-version: 1.0.7
+version: 1.1.0
 apiVersion: v2
 appVersion: 2.13.1
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/tautulli/questions.yaml
+++ b/library/ix-dev/community/tautulli/questions.yaml
@@ -161,6 +161,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/tautulli/questions.yaml
+++ b/library/ix-dev/community/tautulli/questions.yaml
@@ -166,6 +166,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -190,6 +192,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/tautulli/templates/_persistence.tpl
+++ b/library/ix-dev/community/tautulli/templates/_persistence.tpl
@@ -20,10 +20,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.tautulliStorage.additionalStorages }}
   {{ printf "tautulli-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       tautulli:
         tautulli:

--- a/library/ix-dev/community/tdarr/Chart.yaml
+++ b/library/ix-dev/community/tdarr/Chart.yaml
@@ -3,7 +3,7 @@ description: Tdarr is a Distributed Transcoding System
 annotations:
   title: Tdarr
 type: application
-version: 1.0.18
+version: 1.1.0
 apiVersion: v2
 appVersion: '2.00.20.1'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/tdarr/questions.yaml
+++ b/library/ix-dev/community/tdarr/questions.yaml
@@ -334,6 +334,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -358,6 +360,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/tdarr/questions.yaml
+++ b/library/ix-dev/community/tdarr/questions.yaml
@@ -329,6 +329,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/tdarr/templates/_tdarr.tpl
+++ b/library/ix-dev/community/tdarr/templates/_tdarr.tpl
@@ -120,10 +120,24 @@ persistence:
           mountPath: /temp
   {{- range $idx, $storage := .Values.tdarrStorage.additionalStorages }}
   {{ printf "tdarr-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       tdarr:
         tdarr:

--- a/library/ix-dev/community/tiny-media-manager/Chart.yaml
+++ b/library/ix-dev/community/tiny-media-manager/Chart.yaml
@@ -3,7 +3,7 @@ description: tinyMediaManager is a media management tool written in Java/Swing.
 annotations:
   title: tinyMediaManager
 type: application
-version: 1.0.3
+version: 1.1.0
 apiVersion: v2
 appVersion: 4.3.13
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/tiny-media-manager/questions.yaml
+++ b/library/ix-dev/community/tiny-media-manager/questions.yaml
@@ -165,6 +165,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -189,6 +191,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/tiny-media-manager/questions.yaml
+++ b/library/ix-dev/community/tiny-media-manager/questions.yaml
@@ -160,6 +160,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/tiny-media-manager/templates/_persistence.tpl
+++ b/library/ix-dev/community/tiny-media-manager/templates/_persistence.tpl
@@ -18,10 +18,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.tmmStorage.additionalStorages }}
   {{ printf "tmm-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       tmm:
         tmm:

--- a/library/ix-dev/community/transmission/Chart.yaml
+++ b/library/ix-dev/community/transmission/Chart.yaml
@@ -3,7 +3,7 @@ description: Transmission is designed for easy, powerful use.
 annotations:
   title: Transmission
 type: application
-version: 1.0.0
+version: 1.1.0
 apiVersion: v2
 appVersion: 4.0.4
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/transmission/questions.yaml
+++ b/library/ix-dev/community/transmission/questions.yaml
@@ -251,6 +251,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -275,6 +277,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     label: Resources Configuration

--- a/library/ix-dev/community/transmission/questions.yaml
+++ b/library/ix-dev/community/transmission/questions.yaml
@@ -246,6 +246,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/transmission/templates/_persistence.tpl
+++ b/library/ix-dev/community/transmission/templates/_persistence.tpl
@@ -35,10 +35,24 @@ persistence:
           mountPath: /mnt/directories/incomplete
   {{- range $idx, $storage := .Values.transmissionStorage.additionalStorages }}
   {{ printf "transmission-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       transmission:
         transmission:

--- a/library/ix-dev/community/twofactor-auth/Chart.yaml
+++ b/library/ix-dev/community/twofactor-auth/Chart.yaml
@@ -4,7 +4,7 @@ description: 2FAuth is a web based self-hosted alternative to One Time Passcode 
 annotations:
   title: 2FAuth
 type: application
-version: 1.0.2
+version: 1.1.0
 apiVersion: v2
 appVersion: 4.2.3
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/twofactor-auth/questions.yaml
+++ b/library/ix-dev/community/twofactor-auth/questions.yaml
@@ -231,6 +231,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -255,6 +257,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/twofactor-auth/questions.yaml
+++ b/library/ix-dev/community/twofactor-auth/questions.yaml
@@ -226,6 +226,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/twofactor-auth/templates/_persistence.tpl
+++ b/library/ix-dev/community/twofactor-auth/templates/_persistence.tpl
@@ -20,10 +20,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.twofauthStorage.additionalStorages }}
   {{ printf "twofauth-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       twofauth:
         twofauth:

--- a/library/ix-dev/community/unifi-controller/Chart.yaml
+++ b/library/ix-dev/community/unifi-controller/Chart.yaml
@@ -3,7 +3,7 @@ description: Unifi Controller is a network management controller for Unifi Equip
 annotations:
   title: Unifi Controller
 type: application
-version: 1.0.4
+version: 1.1.0
 apiVersion: v2
 appVersion: 7.5.176
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/unifi-controller/questions.yaml
+++ b/library/ix-dev/community/unifi-controller/questions.yaml
@@ -196,6 +196,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/unifi-controller/questions.yaml
+++ b/library/ix-dev/community/unifi-controller/questions.yaml
@@ -201,6 +201,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -225,6 +227,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/unifi-controller/templates/_persistence.tpl
+++ b/library/ix-dev/community/unifi-controller/templates/_persistence.tpl
@@ -22,10 +22,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.unifiStorage.additionalStorages }}
   {{ printf "unifi-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       unifi:
         unifi:

--- a/library/ix-dev/community/unifi-protect-backup/Chart.yaml
+++ b/library/ix-dev/community/unifi-protect-backup/Chart.yaml
@@ -4,7 +4,7 @@ description: Unifi Protect Backup is a python based tool for backing up UniFi Pr
 annotations:
   title: Unifi Protect Backup
 type: application
-version: 1.0.2
+version: 1.1.0
 apiVersion: v2
 appVersion: 0.9.5
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/unifi-protect-backup/questions.yaml
+++ b/library/ix-dev/community/unifi-protect-backup/questions.yaml
@@ -290,6 +290,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/unifi-protect-backup/questions.yaml
+++ b/library/ix-dev/community/unifi-protect-backup/questions.yaml
@@ -295,6 +295,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -319,6 +321,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/unifi-protect-backup/templates/_persistence.tpl
+++ b/library/ix-dev/community/unifi-protect-backup/templates/_persistence.tpl
@@ -31,10 +31,24 @@ persistence:
           mountPath: /tmp
   {{- range $idx, $storage := .Values.upbStorage.additionalStorages }}
   {{ printf "upb-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       unifi-protect:
         unifi-protect:

--- a/library/ix-dev/community/whoogle/Chart.yaml
+++ b/library/ix-dev/community/whoogle/Chart.yaml
@@ -3,7 +3,7 @@ description: Whoogle is a self-hosted, ad-free, privacy-respecting metasearch en
 annotations:
   title: Whoogle
 type: application
-version: 1.0.0
+version: 1.1.0
 apiVersion: v2
 appVersion: 0.8.3
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/whoogle/questions.yaml
+++ b/library/ix-dev/community/whoogle/questions.yaml
@@ -133,6 +133,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -157,6 +159,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/community/whoogle/questions.yaml
+++ b/library/ix-dev/community/whoogle/questions.yaml
@@ -128,6 +128,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/whoogle/templates/_persistence.tpl
+++ b/library/ix-dev/community/whoogle/templates/_persistence.tpl
@@ -36,10 +36,24 @@ persistence:
           mountPath: /mnt/directories/varlibtor
   {{- range $idx, $storage := .Values.whoogleStorage.additionalStorages }}
   {{ printf "whoogle-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       whoogle:
         whoogle:

--- a/library/ix-dev/community/wordpress/Chart.yaml
+++ b/library/ix-dev/community/wordpress/Chart.yaml
@@ -3,7 +3,7 @@ description: Wordpress is a web content management system
 annotations:
   title: Wordpress
 type: application
-version: 1.0.10
+version: 1.1.0
 apiVersion: v2
 appVersion: 6.3.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/wordpress/questions.yaml
+++ b/library/ix-dev/community/wordpress/questions.yaml
@@ -234,6 +234,8 @@ questions:
                             description: Host Path (Path that already exists on the system)
                           - value: "ixVolume"
                             description: ixVolume (Dataset created automatically by the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -258,6 +260,50 @@ questions:
                         default: "storage_entry"
                         $ref:
                           - "normalize/ixVolume"
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     label: ""

--- a/library/ix-dev/community/wordpress/questions.yaml
+++ b/library/ix-dev/community/wordpress/questions.yaml
@@ -229,6 +229,7 @@ questions:
                         type: string
                         required: true
                         default: "ixVolume"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/community/wordpress/templates/_persistence.tpl
+++ b/library/ix-dev/community/wordpress/templates/_persistence.tpl
@@ -16,10 +16,24 @@ persistence:
           mountPath: /var/www/html
   {{- range $idx, $storage := .Values.wpStorage.additionalStorages }}
   {{ printf "wp-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       wordpress:
         wordpress:

--- a/library/ix-dev/enterprise/syncthing/Chart.yaml
+++ b/library/ix-dev/enterprise/syncthing/Chart.yaml
@@ -3,7 +3,7 @@ description: Syncthing is a continuous file synchronization program.
 annotations:
   title: Syncthing
 type: application
-version: 1.0.12
+version: 1.1.0
 apiVersion: v2
 appVersion: '1.23.3'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/enterprise/syncthing/questions.yaml
+++ b/library/ix-dev/enterprise/syncthing/questions.yaml
@@ -180,10 +180,11 @@ questions:
                         type: string
                         required: true
                         default: "hostPath"
-                        hidden: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)
+                          - value: "smb-pv-pvc"
+                            description: SMB Share (Mounts a persistent volume claim to a SMB share)
                     - variable: mountPath
                       label: Mount Path
                       description: The path inside the container to mount the storage.
@@ -197,6 +198,50 @@ questions:
                         type: hostpath
                         show_if: [["type", "=", "hostPath"]]
                         required: true
+                    - variable: server
+                      label: Server
+                      description: The server for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: share
+                      label: Share
+                      description: The share name for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: domain
+                      label: Domain (Optional)
+                      description: The domain for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                    - variable: username
+                      label: Username
+                      description: The username for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                    - variable: password
+                      label: Password
+                      description: The password for the SMB share.
+                      schema:
+                        type: string
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        private: true
+                    - variable: size
+                      label: Size (in Gi)
+                      description: The size of the volume quota.
+                      schema:
+                        type: int
+                        show_if: [["type", "=", "smb-pv-pvc"]]
+                        required: true
+                        min: 1
+                        default: 1
 
   - variable: resources
     group: Resources Configuration

--- a/library/ix-dev/enterprise/syncthing/templates/_persistence.tpl
+++ b/library/ix-dev/enterprise/syncthing/templates/_persistence.tpl
@@ -38,10 +38,24 @@ persistence:
 
   {{- range $idx, $storage := .Values.syncthingStorage.additionalStorages }}
   {{ printf "sync-%v" (int $idx) }}:
+    {{- $size := "" -}}
+    {{- if $storage.size -}}
+      {{- $size = (printf "%vGi" $storage.size) -}}
+    {{- end }}
     enabled: true
     type: {{ $storage.type }}
     datasetName: {{ $storage.datasetName | default "" }}
     hostPath: {{ $storage.hostPath | default "" }}
+    server: {{ $storage.server | default "" }}
+    share: {{ $storage.share | default "" }}
+    domain: {{ $storage.domain | default "" }}
+    username: {{ $storage.username | default "" }}
+    password: {{ $storage.password | default "" }}
+    size: {{ $size }}
+    {{- if eq $storage.type "smb-pv-pvc" }}
+    mountOptions:
+      - key: noperm
+    {{- end }}
     targetSelector:
       syncthing:
         syncthing:


### PR DESCRIPTION
This PR only adds the smb-pv-pvc option to "Additional Storage" section.

For individual storages (eg config or data) needs investigation per app and will be implemented later, to make sure those are not storing any kind of sqlite based files, as its very likely to not play nice with smb.