### PR TITLE
Set storage `type` immutable

### DIFF
--- a/library/ix-dev/charts/elastic-search/Chart.yaml
+++ b/library/ix-dev/charts/elastic-search/Chart.yaml
@@ -4,7 +4,7 @@ description: Elasticsearch is the distributed, RESTful search and analytics engi
 annotations:
   title: Elastic Search
 type: application
-version: 1.0.27
+version: 1.0.28
 apiVersion: v2
 appVersion: 8.10.4
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/elastic-search/questions.yaml
+++ b/library/ix-dev/charts/elastic-search/questions.yaml
@@ -124,6 +124,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/charts/prometheus/Chart.yaml
+++ b/library/ix-dev/charts/prometheus/Chart.yaml
@@ -3,7 +3,7 @@ description: The Prometheus monitoring system and time series database.
 annotations:
   title: Prometheus
 type: application
-version: 1.0.22
+version: 1.0.23
 apiVersion: v2
 appVersion: v2.47.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/prometheus/questions.yaml
+++ b/library/ix-dev/charts/prometheus/questions.yaml
@@ -149,6 +149,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -187,6 +188,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath

--- a/library/ix-dev/community/adguard-home/Chart.yaml
+++ b/library/ix-dev/community/adguard-home/Chart.yaml
@@ -4,7 +4,7 @@ description: Free and open source, powerful network-wide ads & trackers blocking
 annotations:
   title: AdGuard Home
 type: application
-version: 1.0.24
+version: 1.0.25
 apiVersion: v2
 appVersion: 0.107.40
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/adguard-home/questions.yaml
+++ b/library/ix-dev/community/adguard-home/questions.yaml
@@ -91,6 +91,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -129,6 +130,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath

--- a/library/ix-dev/community/autobrr/Chart.yaml
+++ b/library/ix-dev/community/autobrr/Chart.yaml
@@ -3,7 +3,7 @@ description: Autobrr is the modern download automation tool for torrents and use
 annotations:
   title: Autobrr
 type: application
-version: 1.1.1
+version: 1.1.2
 apiVersion: v2
 appVersion: 1.32.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/autobrr/questions.yaml
+++ b/library/ix-dev/community/autobrr/questions.yaml
@@ -168,6 +168,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/autobrr/questions.yaml
+++ b/library/ix-dev/community/autobrr/questions.yaml
@@ -126,6 +126,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/autobrr/questions.yaml
+++ b/library/ix-dev/community/autobrr/questions.yaml
@@ -167,7 +167,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/bazarr/Chart.yaml
+++ b/library/ix-dev/community/bazarr/Chart.yaml
@@ -4,7 +4,7 @@ description: Bazarr is a companion application to Sonarr and Radarr. It manages 
 annotations:
   title: Bazarr
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 1.4.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/bazarr/questions.yaml
+++ b/library/ix-dev/community/bazarr/questions.yaml
@@ -158,6 +158,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/bazarr/questions.yaml
+++ b/library/ix-dev/community/bazarr/questions.yaml
@@ -116,6 +116,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/bazarr/questions.yaml
+++ b/library/ix-dev/community/bazarr/questions.yaml
@@ -157,7 +157,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/briefkasten/Chart.yaml
+++ b/library/ix-dev/community/briefkasten/Chart.yaml
@@ -3,7 +3,7 @@ description: Briefkasten is a self hosted bookmarking app
 annotations:
   title: Briefkasten
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: latest
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/briefkasten/questions.yaml
+++ b/library/ix-dev/community/briefkasten/questions.yaml
@@ -468,6 +468,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/briefkasten/questions.yaml
+++ b/library/ix-dev/community/briefkasten/questions.yaml
@@ -467,7 +467,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/briefkasten/questions.yaml
+++ b/library/ix-dev/community/briefkasten/questions.yaml
@@ -270,6 +270,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -308,6 +309,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -346,6 +348,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -384,6 +387,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -422,6 +426,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/castopod/Chart.yaml
+++ b/library/ix-dev/community/castopod/Chart.yaml
@@ -3,7 +3,7 @@ description: Castopod is an open-source hosting platform made for podcasters who
 annotations:
   title: Castopod
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 1.6.5
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/castopod/questions.yaml
+++ b/library/ix-dev/community/castopod/questions.yaml
@@ -258,7 +258,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/castopod/questions.yaml
+++ b/library/ix-dev/community/castopod/questions.yaml
@@ -256,6 +256,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/castopod/questions.yaml
+++ b/library/ix-dev/community/castopod/questions.yaml
@@ -139,6 +139,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -177,6 +178,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -215,6 +217,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath

--- a/library/ix-dev/community/clamav/Chart.yaml
+++ b/library/ix-dev/community/clamav/Chart.yaml
@@ -3,7 +3,7 @@ description: ClamAV is an open source (GPLv2) anti-virus toolkit.
 annotations:
   title: Clam AV
 type: application
-version: 1.0.11
+version: 1.0.12
 apiVersion: v2
 appVersion: '1.0.1'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/clamav/questions.yaml
+++ b/library/ix-dev/community/clamav/questions.yaml
@@ -118,6 +118,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -156,6 +157,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath

--- a/library/ix-dev/community/cloudflared/Chart.yaml
+++ b/library/ix-dev/community/cloudflared/Chart.yaml
@@ -3,7 +3,7 @@ description: Cloudflared is a client for Cloudflare Tunnel, a daemon that expose
 annotations:
   title: Cloudflared
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 2023.8.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/cloudflared/questions.yaml
+++ b/library/ix-dev/community/cloudflared/questions.yaml
@@ -125,6 +125,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/cloudflared/questions.yaml
+++ b/library/ix-dev/community/cloudflared/questions.yaml
@@ -124,7 +124,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/ddns-updater/Chart.yaml
+++ b/library/ix-dev/community/ddns-updater/Chart.yaml
@@ -3,7 +3,7 @@ description: Lightweight universal DDNS Updater with web UI
 annotations:
   title: DDNS Updater
 type: application
-version: 1.0.15
+version: 1.0.16
 apiVersion: v2
 appVersion: 'v2.5.0'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/ddns-updater/questions.yaml
+++ b/library/ix-dev/community/ddns-updater/questions.yaml
@@ -1346,6 +1346,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/deluge/Chart.yaml
+++ b/library/ix-dev/community/deluge/Chart.yaml
@@ -3,7 +3,7 @@ description: Deluge is a lightweight, Free Software, cross-platform BitTorrent c
 annotations:
   title: Deluge
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: '9.5.3'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/deluge/questions.yaml
+++ b/library/ix-dev/community/deluge/questions.yaml
@@ -240,6 +240,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/deluge/questions.yaml
+++ b/library/ix-dev/community/deluge/questions.yaml
@@ -239,7 +239,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/deluge/questions.yaml
+++ b/library/ix-dev/community/deluge/questions.yaml
@@ -159,6 +159,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -197,6 +198,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/distribution/Chart.yaml
+++ b/library/ix-dev/community/distribution/Chart.yaml
@@ -3,7 +3,7 @@ description: Distribution is a toolkit to pack, ship, store, and deliver contain
 annotations:
   title: Distribution
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 2.8.3
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/distribution/questions.yaml
+++ b/library/ix-dev/community/distribution/questions.yaml
@@ -191,6 +191,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/distribution/questions.yaml
+++ b/library/ix-dev/community/distribution/questions.yaml
@@ -191,7 +191,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/distribution/questions.yaml
+++ b/library/ix-dev/community/distribution/questions.yaml
@@ -150,6 +150,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath

--- a/library/ix-dev/community/drawio/Chart.yaml
+++ b/library/ix-dev/community/drawio/Chart.yaml
@@ -3,7 +3,7 @@ description: Draw.io is a whiteboarding / diagramming software application.
 annotations:
   title: Draw.IO
 type: application
-version: 1.1.1
+version: 1.1.2
 apiVersion: v2
 appVersion: 22.0.8
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/drawio/questions.yaml
+++ b/library/ix-dev/community/drawio/questions.yaml
@@ -108,7 +108,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/drawio/questions.yaml
+++ b/library/ix-dev/community/drawio/questions.yaml
@@ -109,6 +109,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/filebrowser/Chart.yaml
+++ b/library/ix-dev/community/filebrowser/Chart.yaml
@@ -4,7 +4,7 @@ description: File Browser provides a file managing interface within a specified 
 annotations:
   title: File Browser
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 2.25.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/filebrowser/questions.yaml
+++ b/library/ix-dev/community/filebrowser/questions.yaml
@@ -125,6 +125,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/filebrowser/questions.yaml
+++ b/library/ix-dev/community/filebrowser/questions.yaml
@@ -170,6 +170,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/filebrowser/questions.yaml
+++ b/library/ix-dev/community/filebrowser/questions.yaml
@@ -169,7 +169,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/firefly-iii/Chart.yaml
+++ b/library/ix-dev/community/firefly-iii/Chart.yaml
@@ -3,7 +3,7 @@ description: Firefly III is a personal finances manager
 annotations:
   title: Firefly III
 type: application
-version: 1.0.7
+version: 1.0.8
 apiVersion: v2
 appVersion: 6.0.27
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/firefly-iii/questions.yaml
+++ b/library/ix-dev/community/firefly-iii/questions.yaml
@@ -141,6 +141,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -179,6 +180,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -217,6 +219,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath

--- a/library/ix-dev/community/flame/Chart.yaml
+++ b/library/ix-dev/community/flame/Chart.yaml
@@ -3,7 +3,7 @@ description: Flame is a self-hosted start page for your server.
 annotations:
   title: Flame
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 2.3.1
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/flame/questions.yaml
+++ b/library/ix-dev/community/flame/questions.yaml
@@ -143,6 +143,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/flame/questions.yaml
+++ b/library/ix-dev/community/flame/questions.yaml
@@ -101,6 +101,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/flame/questions.yaml
+++ b/library/ix-dev/community/flame/questions.yaml
@@ -142,7 +142,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/frigate/Chart.yaml
+++ b/library/ix-dev/community/frigate/Chart.yaml
@@ -3,7 +3,7 @@ description: Frigate is an NVR With Realtime Object Detection for IP Cameras
 annotations:
   title: Frigate
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 0.12.1
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/frigate/questions.yaml
+++ b/library/ix-dev/community/frigate/questions.yaml
@@ -159,6 +159,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -197,6 +198,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/frigate/questions.yaml
+++ b/library/ix-dev/community/frigate/questions.yaml
@@ -268,6 +268,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/frigate/questions.yaml
+++ b/library/ix-dev/community/frigate/questions.yaml
@@ -267,7 +267,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/fscrawler/Chart.yaml
+++ b/library/ix-dev/community/fscrawler/Chart.yaml
@@ -3,7 +3,7 @@ description: FSCrawler is a crawler that helps to index binary documents such as
 annotations:
   title: FSCrawler
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: '2.9'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/fscrawler/questions.yaml
+++ b/library/ix-dev/community/fscrawler/questions.yaml
@@ -189,7 +189,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/fscrawler/questions.yaml
+++ b/library/ix-dev/community/fscrawler/questions.yaml
@@ -148,6 +148,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/fscrawler/questions.yaml
+++ b/library/ix-dev/community/fscrawler/questions.yaml
@@ -190,6 +190,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/gitea/Chart.yaml
+++ b/library/ix-dev/community/gitea/Chart.yaml
@@ -3,7 +3,7 @@ description: Gitea - Git with a cup of tea
 annotations:
   title: Gitea
 type: application
-version: 1.0.20
+version: 1.0.21
 apiVersion: v2
 appVersion: 1.20.5
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/gitea/questions.yaml
+++ b/library/ix-dev/community/gitea/questions.yaml
@@ -149,6 +149,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -187,6 +188,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -225,6 +227,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -263,6 +266,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath

--- a/library/ix-dev/community/grafana/Chart.yaml
+++ b/library/ix-dev/community/grafana/Chart.yaml
@@ -4,7 +4,7 @@ description: Grafana is the open source analytics & monitoring solution for ever
 annotations:
   title: Grafana
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 10.2.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/grafana/questions.yaml
+++ b/library/ix-dev/community/grafana/questions.yaml
@@ -194,6 +194,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/grafana/questions.yaml
+++ b/library/ix-dev/community/grafana/questions.yaml
@@ -193,7 +193,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/grafana/questions.yaml
+++ b/library/ix-dev/community/grafana/questions.yaml
@@ -152,6 +152,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/homarr/Chart.yaml
+++ b/library/ix-dev/community/homarr/Chart.yaml
@@ -4,7 +4,7 @@ description: Homarr is a sleek, modern dashboard that puts all of your apps and 
 annotations:
   title: Homarr
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 0.13.4
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/homarr/questions.yaml
+++ b/library/ix-dev/community/homarr/questions.yaml
@@ -213,7 +213,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/homarr/questions.yaml
+++ b/library/ix-dev/community/homarr/questions.yaml
@@ -133,6 +133,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -171,6 +172,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/homarr/questions.yaml
+++ b/library/ix-dev/community/homarr/questions.yaml
@@ -214,6 +214,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/homepage/Chart.yaml
+++ b/library/ix-dev/community/homepage/Chart.yaml
@@ -3,7 +3,7 @@ description: Homepage is a modern, secure, highly customizable application dashb
 annotations:
   title: Homepage
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 0.7.1
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/homepage/questions.yaml
+++ b/library/ix-dev/community/homepage/questions.yaml
@@ -132,7 +132,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/homepage/questions.yaml
+++ b/library/ix-dev/community/homepage/questions.yaml
@@ -133,6 +133,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/homepage/questions.yaml
+++ b/library/ix-dev/community/homepage/questions.yaml
@@ -91,6 +91,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/homer/Chart.yaml
+++ b/library/ix-dev/community/homer/Chart.yaml
@@ -4,7 +4,7 @@ description: Homer is a dead simple static HOMepage for your servER to keep your
 annotations:
   title: Homer
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 23.10.1
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/homer/questions.yaml
+++ b/library/ix-dev/community/homer/questions.yaml
@@ -122,6 +122,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/homer/questions.yaml
+++ b/library/ix-dev/community/homer/questions.yaml
@@ -164,6 +164,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/homer/questions.yaml
+++ b/library/ix-dev/community/homer/questions.yaml
@@ -163,7 +163,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/immich/Chart.yaml
+++ b/library/ix-dev/community/immich/Chart.yaml
@@ -3,7 +3,7 @@ description: Immich
 annotations:
   title: Immich
 type: application
-version: 1.0.30
+version: 1.0.31
 apiVersion: v2
 appVersion: 1.82.1
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/immich/questions.yaml
+++ b/library/ix-dev/community/immich/questions.yaml
@@ -93,6 +93,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -131,6 +132,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -169,6 +171,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -207,6 +210,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -245,6 +249,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -304,6 +309,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -342,6 +348,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath

--- a/library/ix-dev/community/ipfs/Chart.yaml
+++ b/library/ix-dev/community/ipfs/Chart.yaml
@@ -4,7 +4,7 @@ description: Interplanetary Filesystem - the Web3 standard for content-addressin
 annotations:
   title: IPFS
 type: application
-version: 1.0.23
+version: 1.0.24
 apiVersion: v2
 appVersion: v0.23.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/ipfs/questions.yaml
+++ b/library/ix-dev/community/ipfs/questions.yaml
@@ -135,6 +135,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -173,6 +174,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath

--- a/library/ix-dev/community/jellyfin/Chart.yaml
+++ b/library/ix-dev/community/jellyfin/Chart.yaml
@@ -4,7 +4,7 @@ description: Jellyfin is a Free Software Media System that puts you in control o
 annotations:
   title: Jellyfin
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 10.8.11
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/jellyfin/questions.yaml
+++ b/library/ix-dev/community/jellyfin/questions.yaml
@@ -124,6 +124,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -162,6 +163,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -201,6 +203,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/jellyfin/questions.yaml
+++ b/library/ix-dev/community/jellyfin/questions.yaml
@@ -270,7 +270,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/jellyfin/questions.yaml
+++ b/library/ix-dev/community/jellyfin/questions.yaml
@@ -271,6 +271,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/jellyseerr/Chart.yaml
+++ b/library/ix-dev/community/jellyseerr/Chart.yaml
@@ -4,7 +4,7 @@ description: Jellyseerr is a free and open source software application for manag
 annotations:
   title: Jellyseerr
 type: application
-version: 1.0.9
+version: 1.0.10
 apiVersion: v2
 appVersion: 1.7.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/jellyseerr/questions.yaml
+++ b/library/ix-dev/community/jellyseerr/questions.yaml
@@ -126,6 +126,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/jenkins/Chart.yaml
+++ b/library/ix-dev/community/jenkins/Chart.yaml
@@ -3,7 +3,7 @@ description: Jenkins is a leading open source automation server,
 annotations:
   title: Jenkins
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 2.414.3
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/jenkins/questions.yaml
+++ b/library/ix-dev/community/jenkins/questions.yaml
@@ -215,7 +215,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/jenkins/questions.yaml
+++ b/library/ix-dev/community/jenkins/questions.yaml
@@ -216,6 +216,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/jenkins/questions.yaml
+++ b/library/ix-dev/community/jenkins/questions.yaml
@@ -173,6 +173,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/joplin/Chart.yaml
+++ b/library/ix-dev/community/joplin/Chart.yaml
@@ -4,7 +4,7 @@ description: Joplin is an open source note-taking app. Capture your thoughts and
 annotations:
   title: Joplin
 type: application
-version: 1.0.3
+version: 1.0.4
 apiVersion: v2
 appVersion: 2.13.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/joplin/questions.yaml
+++ b/library/ix-dev/community/joplin/questions.yaml
@@ -102,6 +102,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -140,6 +141,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath

--- a/library/ix-dev/community/kapowarr/Chart.yaml
+++ b/library/ix-dev/community/kapowarr/Chart.yaml
@@ -3,7 +3,7 @@ description: Kapowarr is a software to build and manage a comic book library, fi
 annotations:
   title: Kapowarr
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 1.0.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/kapowarr/questions.yaml
+++ b/library/ix-dev/community/kapowarr/questions.yaml
@@ -235,7 +235,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/kapowarr/questions.yaml
+++ b/library/ix-dev/community/kapowarr/questions.yaml
@@ -116,6 +116,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -154,6 +155,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -192,6 +194,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/kapowarr/questions.yaml
+++ b/library/ix-dev/community/kapowarr/questions.yaml
@@ -236,6 +236,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/kavita/Chart.yaml
+++ b/library/ix-dev/community/kavita/Chart.yaml
@@ -3,7 +3,7 @@ description: Kavita is a fast, feature rich, cross platform reading server.
 annotations:
   title: Kavita
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 0.7.8
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/kavita/questions.yaml
+++ b/library/ix-dev/community/kavita/questions.yaml
@@ -137,6 +137,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/kavita/questions.yaml
+++ b/library/ix-dev/community/kavita/questions.yaml
@@ -94,6 +94,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/kavita/questions.yaml
+++ b/library/ix-dev/community/kavita/questions.yaml
@@ -136,7 +136,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/komga/Chart.yaml
+++ b/library/ix-dev/community/komga/Chart.yaml
@@ -3,7 +3,7 @@ description: Komga is a free and open source comics/mangas server.
 annotations:
   title: Komga
 type: application
-version: 1.1.1
+version: 1.1.2
 apiVersion: v2
 appVersion: 1.6.4
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/komga/questions.yaml
+++ b/library/ix-dev/community/komga/questions.yaml
@@ -168,6 +168,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/komga/questions.yaml
+++ b/library/ix-dev/community/komga/questions.yaml
@@ -126,6 +126,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/komga/questions.yaml
+++ b/library/ix-dev/community/komga/questions.yaml
@@ -167,7 +167,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/lidarr/Chart.yaml
+++ b/library/ix-dev/community/lidarr/Chart.yaml
@@ -3,7 +3,7 @@ description: Lidarr is a music collection manager for Usenet and BitTorrent user
 annotations:
   title: Lidarr
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 1.4.5.3639
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/lidarr/questions.yaml
+++ b/library/ix-dev/community/lidarr/questions.yaml
@@ -165,6 +165,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/lidarr/questions.yaml
+++ b/library/ix-dev/community/lidarr/questions.yaml
@@ -123,6 +123,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/lidarr/questions.yaml
+++ b/library/ix-dev/community/lidarr/questions.yaml
@@ -164,7 +164,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/linkding/Chart.yaml
+++ b/library/ix-dev/community/linkding/Chart.yaml
@@ -3,7 +3,7 @@ description: Linkding is a bookmark manager that you can host yourself.
 annotations:
   title: Linkding
 type: application
-version: 1.1.1
+version: 1.1.2
 apiVersion: v2
 appVersion: 1.22.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/linkding/questions.yaml
+++ b/library/ix-dev/community/linkding/questions.yaml
@@ -194,6 +194,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -232,6 +233,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -270,6 +272,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/linkding/questions.yaml
+++ b/library/ix-dev/community/linkding/questions.yaml
@@ -313,7 +313,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/linkding/questions.yaml
+++ b/library/ix-dev/community/linkding/questions.yaml
@@ -314,6 +314,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/listmonk/Chart.yaml
+++ b/library/ix-dev/community/listmonk/Chart.yaml
@@ -3,7 +3,7 @@ description: Listmonk is a self-hosted newsletter and mailing list manager.
 annotations:
   title: Listmonk
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: v2.5.1
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/listmonk/questions.yaml
+++ b/library/ix-dev/community/listmonk/questions.yaml
@@ -251,7 +251,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/listmonk/questions.yaml
+++ b/library/ix-dev/community/listmonk/questions.yaml
@@ -132,6 +132,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -170,6 +171,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -208,6 +210,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath

--- a/library/ix-dev/community/listmonk/questions.yaml
+++ b/library/ix-dev/community/listmonk/questions.yaml
@@ -249,6 +249,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/logseq/Chart.yaml
+++ b/library/ix-dev/community/logseq/Chart.yaml
@@ -3,7 +3,7 @@ description: Logseq is a privacy-first, open-source platform for knowledge manag
 annotations:
   title: Logseq
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: latest
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/logseq/questions.yaml
+++ b/library/ix-dev/community/logseq/questions.yaml
@@ -126,7 +126,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/logseq/questions.yaml
+++ b/library/ix-dev/community/logseq/questions.yaml
@@ -127,6 +127,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/metube/Chart.yaml
+++ b/library/ix-dev/community/metube/Chart.yaml
@@ -4,7 +4,7 @@ description: MeTube is a web GUI for youtube-dl (using the yt-dlp fork) with pla
 annotations:
   title: MeTube
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: '2023-10-20'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/metube/questions.yaml
+++ b/library/ix-dev/community/metube/questions.yaml
@@ -172,6 +172,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/metube/questions.yaml
+++ b/library/ix-dev/community/metube/questions.yaml
@@ -130,6 +130,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/metube/questions.yaml
+++ b/library/ix-dev/community/metube/questions.yaml
@@ -171,7 +171,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/minecraft/Chart.yaml
+++ b/library/ix-dev/community/minecraft/Chart.yaml
@@ -3,7 +3,7 @@ description: Minecraft is a sandbox game
 annotations:
   title: Minecraft
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 2023.10.1
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/minecraft/questions.yaml
+++ b/library/ix-dev/community/minecraft/questions.yaml
@@ -536,6 +536,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/minecraft/questions.yaml
+++ b/library/ix-dev/community/minecraft/questions.yaml
@@ -578,6 +578,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/minecraft/questions.yaml
+++ b/library/ix-dev/community/minecraft/questions.yaml
@@ -577,7 +577,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/mineos/Chart.yaml
+++ b/library/ix-dev/community/mineos/Chart.yaml
@@ -3,7 +3,7 @@ description: MineOS is a server front-end to ease managing Minecraft administrat
 annotations:
   title: MineOS
 type: application
-version: 1.0.10
+version: 1.0.11
 apiVersion: v2
 appVersion: 'latest'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/mineos/questions.yaml
+++ b/library/ix-dev/community/mineos/questions.yaml
@@ -179,6 +179,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath

--- a/library/ix-dev/community/mumble/Chart.yaml
+++ b/library/ix-dev/community/mumble/Chart.yaml
@@ -3,7 +3,7 @@ description: Mumble is a free, open source, low latency, high quality voice chat
 annotations:
   title: Mumble
 type: application
-version: 1.0.12
+version: 1.0.13
 apiVersion: v2
 appVersion: 'v1.4.230'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/mumble/questions.yaml
+++ b/library/ix-dev/community/mumble/questions.yaml
@@ -137,6 +137,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath

--- a/library/ix-dev/community/n8n/Chart.yaml
+++ b/library/ix-dev/community/n8n/Chart.yaml
@@ -3,7 +3,7 @@ description: n8n is an extendable workflow automation tool.
 annotations:
   title: n8n
 type: application
-version: 1.1.1
+version: 1.1.2
 apiVersion: v2
 appVersion: 1.14.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/n8n/questions.yaml
+++ b/library/ix-dev/community/n8n/questions.yaml
@@ -138,6 +138,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -176,6 +177,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -214,6 +216,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath

--- a/library/ix-dev/community/n8n/questions.yaml
+++ b/library/ix-dev/community/n8n/questions.yaml
@@ -257,7 +257,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/n8n/questions.yaml
+++ b/library/ix-dev/community/n8n/questions.yaml
@@ -255,6 +255,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/navidrome/Chart.yaml
+++ b/library/ix-dev/community/navidrome/Chart.yaml
@@ -3,7 +3,7 @@ description: Navidrome is a personal streaming service
 annotations:
   title: Navidrome
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: '0.49.3'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/navidrome/questions.yaml
+++ b/library/ix-dev/community/navidrome/questions.yaml
@@ -122,6 +122,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -160,6 +161,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/navidrome/questions.yaml
+++ b/library/ix-dev/community/navidrome/questions.yaml
@@ -203,6 +203,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/navidrome/questions.yaml
+++ b/library/ix-dev/community/navidrome/questions.yaml
@@ -202,7 +202,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/nginx-proxy-manager/Chart.yaml
+++ b/library/ix-dev/community/nginx-proxy-manager/Chart.yaml
@@ -3,7 +3,7 @@ description: Expose your services easily and securely
 annotations:
   title: Nginx Proxy Manager
 type: application
-version: 1.0.17
+version: 1.0.18
 apiVersion: v2
 appVersion: 2.10.4
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/nginx-proxy-manager/questions.yaml
+++ b/library/ix-dev/community/nginx-proxy-manager/questions.yaml
@@ -114,6 +114,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -152,6 +153,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/node-red/Chart.yaml
+++ b/library/ix-dev/community/node-red/Chart.yaml
@@ -4,7 +4,7 @@ description: Node-RED is a programming tool for wiring together hardware devices
 annotations:
   title: Node-RED
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 3.1.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/node-red/questions.yaml
+++ b/library/ix-dev/community/node-red/questions.yaml
@@ -172,7 +172,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/node-red/questions.yaml
+++ b/library/ix-dev/community/node-red/questions.yaml
@@ -131,6 +131,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/node-red/questions.yaml
+++ b/library/ix-dev/community/node-red/questions.yaml
@@ -173,6 +173,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/odoo/Chart.yaml
+++ b/library/ix-dev/community/odoo/Chart.yaml
@@ -3,7 +3,7 @@ description: Odoo is a suite of web based open source business apps.
 annotations:
   title: Odoo
 type: application
-version: 1.0.1
+version: 1.0.2
 apiVersion: v2
 appVersion: '16.0'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/odoo/questions.yaml
+++ b/library/ix-dev/community/odoo/questions.yaml
@@ -117,6 +117,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -155,6 +156,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -193,6 +195,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -231,6 +234,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath

--- a/library/ix-dev/community/omada-controller/Chart.yaml
+++ b/library/ix-dev/community/omada-controller/Chart.yaml
@@ -4,7 +4,7 @@ description: Omada Controller (TP-Link) is a network management controller for T
 annotations:
   title: Omada Controller
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: '5.12'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/omada-controller/questions.yaml
+++ b/library/ix-dev/community/omada-controller/questions.yaml
@@ -297,6 +297,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/omada-controller/questions.yaml
+++ b/library/ix-dev/community/omada-controller/questions.yaml
@@ -216,6 +216,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -254,6 +255,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/omada-controller/questions.yaml
+++ b/library/ix-dev/community/omada-controller/questions.yaml
@@ -296,7 +296,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/overseerr/Chart.yaml
+++ b/library/ix-dev/community/overseerr/Chart.yaml
@@ -3,7 +3,7 @@ description: Overseerr is a free and open source software application for managi
 annotations:
   title: Overseerr
 type: application
-version: 1.0.15
+version: 1.0.16
 apiVersion: v2
 appVersion: 1.33.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/overseerr/questions.yaml
+++ b/library/ix-dev/community/overseerr/questions.yaml
@@ -126,6 +126,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/paperless-ngx/Chart.yaml
+++ b/library/ix-dev/community/paperless-ngx/Chart.yaml
@@ -3,7 +3,7 @@ description: Paperless-ngx is a document management system that transforms your 
 annotations:
   title: Paperless-ngx
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 1.17.4
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/paperless-ngx/questions.yaml
+++ b/library/ix-dev/community/paperless-ngx/questions.yaml
@@ -165,6 +165,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -203,6 +204,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -241,6 +243,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -281,6 +284,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/paperless-ngx/questions.yaml
+++ b/library/ix-dev/community/paperless-ngx/questions.yaml
@@ -404,6 +404,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/paperless-ngx/questions.yaml
+++ b/library/ix-dev/community/paperless-ngx/questions.yaml
@@ -405,7 +405,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/paperless-ngx/questions.yaml
+++ b/library/ix-dev/community/paperless-ngx/questions.yaml
@@ -324,6 +324,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -362,6 +363,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath

--- a/library/ix-dev/community/passbolt/Chart.yaml
+++ b/library/ix-dev/community/passbolt/Chart.yaml
@@ -3,7 +3,7 @@ description: Passbolt is a security-first, open source password manager
 annotations:
   title: Passbolt
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 4.3.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/passbolt/questions.yaml
+++ b/library/ix-dev/community/passbolt/questions.yaml
@@ -109,6 +109,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -147,6 +148,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -185,6 +187,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -223,6 +226,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath

--- a/library/ix-dev/community/passbolt/questions.yaml
+++ b/library/ix-dev/community/passbolt/questions.yaml
@@ -264,6 +264,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/passbolt/questions.yaml
+++ b/library/ix-dev/community/passbolt/questions.yaml
@@ -267,7 +267,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/pgadmin/Chart.yaml
+++ b/library/ix-dev/community/pgadmin/Chart.yaml
@@ -4,7 +4,7 @@ description: pgAdmin is the most popular and feature rich Open Source administra
 annotations:
   title: pgAdmin
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: '7.8'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/pgadmin/questions.yaml
+++ b/library/ix-dev/community/pgadmin/questions.yaml
@@ -155,7 +155,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/pgadmin/questions.yaml
+++ b/library/ix-dev/community/pgadmin/questions.yaml
@@ -156,6 +156,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/pgadmin/questions.yaml
+++ b/library/ix-dev/community/pgadmin/questions.yaml
@@ -114,6 +114,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/pigallery2/Chart.yaml
+++ b/library/ix-dev/community/pigallery2/Chart.yaml
@@ -3,7 +3,7 @@ description: PiGallery2 is a fast directory-first photo gallery website, with ri
 annotations:
   title: PiGallery2
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 2.0.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/pigallery2/questions.yaml
+++ b/library/ix-dev/community/pigallery2/questions.yaml
@@ -282,6 +282,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/pigallery2/questions.yaml
+++ b/library/ix-dev/community/pigallery2/questions.yaml
@@ -281,7 +281,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/pigallery2/questions.yaml
+++ b/library/ix-dev/community/pigallery2/questions.yaml
@@ -123,6 +123,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -161,6 +162,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -199,6 +201,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -237,6 +240,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/piwigo/Chart.yaml
+++ b/library/ix-dev/community/piwigo/Chart.yaml
@@ -3,7 +3,7 @@ description: Piwigo is a photo gallery software for the web that comes with powe
 annotations:
   title: Piwigo
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 13.8.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/piwigo/questions.yaml
+++ b/library/ix-dev/community/piwigo/questions.yaml
@@ -295,6 +295,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -333,6 +334,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -371,6 +373,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -409,6 +412,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath

--- a/library/ix-dev/community/piwigo/questions.yaml
+++ b/library/ix-dev/community/piwigo/questions.yaml
@@ -450,6 +450,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/piwigo/questions.yaml
+++ b/library/ix-dev/community/piwigo/questions.yaml
@@ -453,7 +453,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/planka/Chart.yaml
+++ b/library/ix-dev/community/planka/Chart.yaml
@@ -3,7 +3,7 @@ description: Planka is an Elegant open source project tracking
 annotations:
   title: Planka
 type: application
-version: 1.1.1
+version: 1.1.2
 apiVersion: v2
 appVersion: 1.14.3
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/planka/questions.yaml
+++ b/library/ix-dev/community/planka/questions.yaml
@@ -138,6 +138,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -176,6 +177,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -214,6 +216,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -252,6 +255,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -290,6 +294,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/planka/questions.yaml
+++ b/library/ix-dev/community/planka/questions.yaml
@@ -335,7 +335,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/planka/questions.yaml
+++ b/library/ix-dev/community/planka/questions.yaml
@@ -336,6 +336,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/plex-auto-languages/Chart.yaml
+++ b/library/ix-dev/community/plex-auto-languages/Chart.yaml
@@ -3,7 +3,7 @@ description: Plex Auto Languages offer automated language selection for Plex TV 
 annotations:
   title: Plex Auto Languages
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 1.2.3
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/plex-auto-languages/questions.yaml
+++ b/library/ix-dev/community/plex-auto-languages/questions.yaml
@@ -106,6 +106,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/plex-auto-languages/questions.yaml
+++ b/library/ix-dev/community/plex-auto-languages/questions.yaml
@@ -147,7 +147,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/plex-auto-languages/questions.yaml
+++ b/library/ix-dev/community/plex-auto-languages/questions.yaml
@@ -148,6 +148,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/prowlarr/Chart.yaml
+++ b/library/ix-dev/community/prowlarr/Chart.yaml
@@ -4,7 +4,7 @@ description: Prowlarr is an indexer manager/proxy to integrate with your various
 annotations:
   title: Prowlarr
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 1.10.0.4047
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/prowlarr/questions.yaml
+++ b/library/ix-dev/community/prowlarr/questions.yaml
@@ -165,6 +165,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/prowlarr/questions.yaml
+++ b/library/ix-dev/community/prowlarr/questions.yaml
@@ -123,6 +123,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/prowlarr/questions.yaml
+++ b/library/ix-dev/community/prowlarr/questions.yaml
@@ -164,7 +164,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/qbittorrent/Chart.yaml
+++ b/library/ix-dev/community/qbittorrent/Chart.yaml
@@ -4,7 +4,7 @@ description: The qBittorrent project aims to provide an open-source software alt
 annotations:
   title: qBittorrent
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 4.6.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/qbittorrent/questions.yaml
+++ b/library/ix-dev/community/qbittorrent/questions.yaml
@@ -205,7 +205,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/qbittorrent/questions.yaml
+++ b/library/ix-dev/community/qbittorrent/questions.yaml
@@ -125,6 +125,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -163,6 +164,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath

--- a/library/ix-dev/community/qbittorrent/questions.yaml
+++ b/library/ix-dev/community/qbittorrent/questions.yaml
@@ -204,6 +204,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/radarr/Chart.yaml
+++ b/library/ix-dev/community/radarr/Chart.yaml
@@ -3,7 +3,7 @@ description: Radarr is a movie collection manager for Usenet and BitTorrent user
 annotations:
   title: Radarr
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 5.0.3.8127
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/radarr/questions.yaml
+++ b/library/ix-dev/community/radarr/questions.yaml
@@ -165,6 +165,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/radarr/questions.yaml
+++ b/library/ix-dev/community/radarr/questions.yaml
@@ -123,6 +123,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/radarr/questions.yaml
+++ b/library/ix-dev/community/radarr/questions.yaml
@@ -164,7 +164,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/readarr/Chart.yaml
+++ b/library/ix-dev/community/readarr/Chart.yaml
@@ -4,7 +4,7 @@ description: Readarr is an ebook and audiobook collection manager for Usenet and
 annotations:
   title: Readarr
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 0.3.8.2267
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/readarr/questions.yaml
+++ b/library/ix-dev/community/readarr/questions.yaml
@@ -165,6 +165,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/readarr/questions.yaml
+++ b/library/ix-dev/community/readarr/questions.yaml
@@ -123,6 +123,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/readarr/questions.yaml
+++ b/library/ix-dev/community/readarr/questions.yaml
@@ -164,7 +164,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/recyclarr/Chart.yaml
+++ b/library/ix-dev/community/recyclarr/Chart.yaml
@@ -4,7 +4,7 @@ description: Recyclarr synchronizes recommended settings from the TRaSH guides t
 annotations:
   title: Recyclarr
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 6.0.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/recyclarr/questions.yaml
+++ b/library/ix-dev/community/recyclarr/questions.yaml
@@ -108,6 +108,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/recyclarr/questions.yaml
+++ b/library/ix-dev/community/recyclarr/questions.yaml
@@ -149,7 +149,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/recyclarr/questions.yaml
+++ b/library/ix-dev/community/recyclarr/questions.yaml
@@ -150,6 +150,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/redis/Chart.yaml
+++ b/library/ix-dev/community/redis/Chart.yaml
@@ -4,7 +4,7 @@ description: Redis. The open source, in-memory data store used by millions of de
 annotations:
   title: Redis
 type: application
-version: 1.0.10
+version: 1.0.11
 apiVersion: v2
 appVersion: 7.2.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/redis/questions.yaml
+++ b/library/ix-dev/community/redis/questions.yaml
@@ -79,6 +79,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/rust-desk/Chart.yaml
+++ b/library/ix-dev/community/rust-desk/Chart.yaml
@@ -3,7 +3,7 @@ description: Rust Desk is an open-source remote desktop, and alternative to Team
 annotations:
   title: Rust Desk
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: '1.1.8-2'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/rust-desk/questions.yaml
+++ b/library/ix-dev/community/rust-desk/questions.yaml
@@ -226,7 +226,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/rust-desk/questions.yaml
+++ b/library/ix-dev/community/rust-desk/questions.yaml
@@ -185,6 +185,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/rust-desk/questions.yaml
+++ b/library/ix-dev/community/rust-desk/questions.yaml
@@ -227,6 +227,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/sabnzbd/Chart.yaml
+++ b/library/ix-dev/community/sabnzbd/Chart.yaml
@@ -3,7 +3,7 @@ description: SABnzbd is an Open Source Binary Newsreader written in Python.
 annotations:
   title: SABnzbd
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 4.1.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/sabnzbd/questions.yaml
+++ b/library/ix-dev/community/sabnzbd/questions.yaml
@@ -158,6 +158,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/sabnzbd/questions.yaml
+++ b/library/ix-dev/community/sabnzbd/questions.yaml
@@ -116,6 +116,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/sabnzbd/questions.yaml
+++ b/library/ix-dev/community/sabnzbd/questions.yaml
@@ -157,7 +157,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/searxng/Chart.yaml
+++ b/library/ix-dev/community/searxng/Chart.yaml
@@ -3,7 +3,7 @@ description: SearXNG is a privacy-respecting, hackable metasearch engine
 annotations:
   title: SearXNG
 type: application
-version: 1.1.1
+version: 1.1.2
 apiVersion: v2
 appVersion: 2023.10.27
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/searxng/questions.yaml
+++ b/library/ix-dev/community/searxng/questions.yaml
@@ -139,7 +139,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/searxng/questions.yaml
+++ b/library/ix-dev/community/searxng/questions.yaml
@@ -140,6 +140,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/searxng/questions.yaml
+++ b/library/ix-dev/community/searxng/questions.yaml
@@ -98,6 +98,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/sftpgo/Chart.yaml
+++ b/library/ix-dev/community/sftpgo/Chart.yaml
@@ -3,7 +3,7 @@ description: SFTPGo is a fully featured and highly configurable SFTP server with
 annotations:
   title: SFTPGo
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: v2.5.4
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/sftpgo/questions.yaml
+++ b/library/ix-dev/community/sftpgo/questions.yaml
@@ -369,7 +369,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/sftpgo/questions.yaml
+++ b/library/ix-dev/community/sftpgo/questions.yaml
@@ -250,6 +250,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -288,6 +289,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -326,6 +328,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/sftpgo/questions.yaml
+++ b/library/ix-dev/community/sftpgo/questions.yaml
@@ -370,6 +370,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/sonarr/Chart.yaml
+++ b/library/ix-dev/community/sonarr/Chart.yaml
@@ -3,7 +3,7 @@ description: Sonarr is a PVR for Usenet and BitTorrent users.
 annotations:
   title: Sonarr
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: '3.0.10.1567'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/sonarr/questions.yaml
+++ b/library/ix-dev/community/sonarr/questions.yaml
@@ -165,6 +165,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/sonarr/questions.yaml
+++ b/library/ix-dev/community/sonarr/questions.yaml
@@ -123,6 +123,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/sonarr/questions.yaml
+++ b/library/ix-dev/community/sonarr/questions.yaml
@@ -164,7 +164,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/tautulli/Chart.yaml
+++ b/library/ix-dev/community/tautulli/Chart.yaml
@@ -4,7 +4,7 @@ description: Tautulli is a python based web application for monitoring, analytic
 annotations:
   title: Tautulli
 type: application
-version: 1.1.1
+version: 1.1.2
 apiVersion: v2
 appVersion: 2.13.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/tautulli/questions.yaml
+++ b/library/ix-dev/community/tautulli/questions.yaml
@@ -158,6 +158,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/tautulli/questions.yaml
+++ b/library/ix-dev/community/tautulli/questions.yaml
@@ -116,6 +116,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/tautulli/questions.yaml
+++ b/library/ix-dev/community/tautulli/questions.yaml
@@ -157,7 +157,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/tdarr/Chart.yaml
+++ b/library/ix-dev/community/tdarr/Chart.yaml
@@ -3,7 +3,7 @@ description: Tdarr is a Distributed Transcoding System
 annotations:
   title: Tdarr
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: '2.00.20.1'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/tdarr/questions.yaml
+++ b/library/ix-dev/community/tdarr/questions.yaml
@@ -329,6 +329,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/tdarr/questions.yaml
+++ b/library/ix-dev/community/tdarr/questions.yaml
@@ -328,7 +328,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/tdarr/questions.yaml
+++ b/library/ix-dev/community/tdarr/questions.yaml
@@ -144,6 +144,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -182,6 +183,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -220,6 +222,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -259,6 +262,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/terraria/Chart.yaml
+++ b/library/ix-dev/community/terraria/Chart.yaml
@@ -3,7 +3,7 @@ description: Terraria is a land of adventure! A land of mystery! A land that's y
 annotations:
   title: Terraria
 type: application
-version: 1.0.11
+version: 1.0.12
 apiVersion: v2
 appVersion: '1.4.4.9'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/terraria/questions.yaml
+++ b/library/ix-dev/community/terraria/questions.yaml
@@ -226,6 +226,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -264,6 +265,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/tftpd-hpa/Chart.yaml
+++ b/library/ix-dev/community/tftpd-hpa/Chart.yaml
@@ -3,7 +3,7 @@ description: A lightweight tftp-server
 annotations:
   title: TFTP Server
 type: application
-version: 1.0.8
+version: 1.0.9
 apiVersion: v2
 appVersion: 1.0.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/tftpd-hpa/questions.yaml
+++ b/library/ix-dev/community/tftpd-hpa/questions.yaml
@@ -103,6 +103,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/tiny-media-manager/Chart.yaml
+++ b/library/ix-dev/community/tiny-media-manager/Chart.yaml
@@ -3,7 +3,7 @@ description: tinyMediaManager is a media management tool written in Java/Swing.
 annotations:
   title: tinyMediaManager
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 4.3.13
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/tiny-media-manager/questions.yaml
+++ b/library/ix-dev/community/tiny-media-manager/questions.yaml
@@ -115,6 +115,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/tiny-media-manager/questions.yaml
+++ b/library/ix-dev/community/tiny-media-manager/questions.yaml
@@ -156,7 +156,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/tiny-media-manager/questions.yaml
+++ b/library/ix-dev/community/tiny-media-manager/questions.yaml
@@ -157,6 +157,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/transmission/Chart.yaml
+++ b/library/ix-dev/community/transmission/Chart.yaml
@@ -3,7 +3,7 @@ description: Transmission is designed for easy, powerful use.
 annotations:
   title: Transmission
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 4.0.4
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/transmission/questions.yaml
+++ b/library/ix-dev/community/transmission/questions.yaml
@@ -244,7 +244,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/transmission/questions.yaml
+++ b/library/ix-dev/community/transmission/questions.yaml
@@ -242,6 +242,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/transmission/questions.yaml
+++ b/library/ix-dev/community/transmission/questions.yaml
@@ -125,6 +125,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -163,6 +164,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -201,6 +203,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath

--- a/library/ix-dev/community/twofactor-auth/Chart.yaml
+++ b/library/ix-dev/community/twofactor-auth/Chart.yaml
@@ -4,7 +4,7 @@ description: 2FAuth is a web based self-hosted alternative to One Time Passcode 
 annotations:
   title: 2FAuth
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 4.2.3
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/twofactor-auth/questions.yaml
+++ b/library/ix-dev/community/twofactor-auth/questions.yaml
@@ -181,6 +181,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/twofactor-auth/questions.yaml
+++ b/library/ix-dev/community/twofactor-auth/questions.yaml
@@ -222,7 +222,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/twofactor-auth/questions.yaml
+++ b/library/ix-dev/community/twofactor-auth/questions.yaml
@@ -223,6 +223,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/unifi-controller/Chart.yaml
+++ b/library/ix-dev/community/unifi-controller/Chart.yaml
@@ -3,7 +3,7 @@ description: Unifi Controller is a network management controller for Unifi Equip
 annotations:
   title: Unifi Controller
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 7.5.176
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/unifi-controller/questions.yaml
+++ b/library/ix-dev/community/unifi-controller/questions.yaml
@@ -192,7 +192,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/unifi-controller/questions.yaml
+++ b/library/ix-dev/community/unifi-controller/questions.yaml
@@ -151,6 +151,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/unifi-controller/questions.yaml
+++ b/library/ix-dev/community/unifi-controller/questions.yaml
@@ -193,6 +193,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/unifi-protect-backup/Chart.yaml
+++ b/library/ix-dev/community/unifi-protect-backup/Chart.yaml
@@ -4,7 +4,7 @@ description: Unifi Protect Backup is a python based tool for backing up UniFi Pr
 annotations:
   title: Unifi Protect Backup
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 0.9.5
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/unifi-protect-backup/questions.yaml
+++ b/library/ix-dev/community/unifi-protect-backup/questions.yaml
@@ -287,7 +287,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/unifi-protect-backup/questions.yaml
+++ b/library/ix-dev/community/unifi-protect-backup/questions.yaml
@@ -207,6 +207,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -245,6 +246,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"

--- a/library/ix-dev/community/unifi-protect-backup/questions.yaml
+++ b/library/ix-dev/community/unifi-protect-backup/questions.yaml
@@ -288,6 +288,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/vaultwarden/Chart.yaml
+++ b/library/ix-dev/community/vaultwarden/Chart.yaml
@@ -4,7 +4,7 @@ description: Alternative implementation of the Bitwarden server API written in R
 annotations:
   title: Vaultwarden
 type: application
-version: 1.0.25
+version: 1.0.26
 apiVersion: v2
 appVersion: 1.29.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/vaultwarden/questions.yaml
+++ b/library/ix-dev/community/vaultwarden/questions.yaml
@@ -175,6 +175,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -213,6 +214,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -251,6 +253,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath

--- a/library/ix-dev/community/whoogle/Chart.yaml
+++ b/library/ix-dev/community/whoogle/Chart.yaml
@@ -3,7 +3,7 @@ description: Whoogle is a self-hosted, ad-free, privacy-respecting metasearch en
 annotations:
   title: Whoogle
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 0.8.3
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/whoogle/questions.yaml
+++ b/library/ix-dev/community/whoogle/questions.yaml
@@ -123,7 +123,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/whoogle/questions.yaml
+++ b/library/ix-dev/community/whoogle/questions.yaml
@@ -124,6 +124,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/community/wordpress/Chart.yaml
+++ b/library/ix-dev/community/wordpress/Chart.yaml
@@ -3,7 +3,7 @@ description: Wordpress is a web content management system
 annotations:
   title: Wordpress
 type: application
-version: 1.1.0
+version: 1.1.1
 apiVersion: v2
 appVersion: 6.3.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/wordpress/questions.yaml
+++ b/library/ix-dev/community/wordpress/questions.yaml
@@ -108,6 +108,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -146,6 +147,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath
@@ -184,6 +186,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: ixVolume
                   enum:
                     - value: hostPath

--- a/library/ix-dev/community/wordpress/questions.yaml
+++ b/library/ix-dev/community/wordpress/questions.yaml
@@ -227,7 +227,7 @@ questions:
                       label: Type
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string

--- a/library/ix-dev/community/wordpress/questions.yaml
+++ b/library/ix-dev/community/wordpress/questions.yaml
@@ -225,6 +225,7 @@ questions:
                       description: |
                         ixVolume: Is dataset created automatically by the system.</br>
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Is a SMB share that is mounted to a persistent volume claim.
                       schema:
                         type: string
                         required: true

--- a/library/ix-dev/enterprise/syncthing/Chart.yaml
+++ b/library/ix-dev/enterprise/syncthing/Chart.yaml
@@ -3,7 +3,7 @@ description: Syncthing is a continuous file synchronization program.
 annotations:
   title: Syncthing
 type: application
-version: 1.1.1
+version: 1.1.2
 apiVersion: v2
 appVersion: '1.23.3'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/enterprise/syncthing/questions.yaml
+++ b/library/ix-dev/enterprise/syncthing/questions.yaml
@@ -131,6 +131,7 @@ questions:
                 schema:
                   type: string
                   required: true
+                  immutable: true
                   default: "ixVolume"
                   enum:
                     - value: "hostPath"
@@ -176,10 +177,12 @@ questions:
                       label: Type
                       description: |
                         Host Path: Is a path that already exists on the system.
+                        SMB Share: Mounts a persistent volume claim to a SMB share.
                       schema:
                         type: string
                         required: true
                         default: "hostPath"
+                        immutable: true
                         enum:
                           - value: "hostPath"
                             description: Host Path (Path that already exists on the system)

--- a/library/ix-dev/enterprise/syncthing/questions.yaml
+++ b/library/ix-dev/enterprise/syncthing/questions.yaml
@@ -176,7 +176,7 @@ questions:
                     - variable: type
                       label: Type
                       description: |
-                        Host Path: Is a path that already exists on the system.
+                        Host Path: Is a path that already exists on the system.</br>
                         SMB Share: Mounts a persistent volume claim to a SMB share.
                       schema:
                         type: string


### PR DESCRIPTION
All dependent properties are already immutable. Having the type non-immutable does not make sense.
If user tries to change type, the fields are already locked. 
Additionally, changing the storage type might lead to unpredictable scenarios based on how each app handles it.

---

https://ixsystems.atlassian.net/browse/TNCHARTS-304