### PR TITLE
minio/charts: fix wrong order in questions that cause fields to be hidden

### DIFF
--- a/library/ix-dev/charts/minio/Chart.yaml
+++ b/library/ix-dev/charts/minio/Chart.yaml
@@ -3,7 +3,7 @@ description: High Performance, Kubernetes Native Object Storage
 annotations:
   title: MinIO
 type: application
-version: 1.7.19
+version: 1.7.20
 apiVersion: v2
 appVersion: '2023-03-13'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/minio/questions.yaml
+++ b/library/ix-dev/charts/minio/questions.yaml
@@ -165,6 +165,15 @@ questions:
             default: 9002
             required: true
 
+  - variable: certificate
+    description: "Minio Certificate"
+    label: "Minio Certificate"
+    group: "Minio Configuration"
+    schema:
+      type: int
+      $ref:
+        - "definitions/certificate"
+
   - variable: minioDomain
     label: "Minio Domain Name"
     description: "This is only required if TLS is configured for Minio"
@@ -174,15 +183,6 @@ questions:
       default: null
       "null": true
       show_if: [["certificate", "!=", null]]
-
-  - variable: certificate
-    description: "Minio Certificate"
-    label: "Minio Certificate"
-    group: "Minio Configuration"
-    schema:
-      type: int
-      $ref:
-        - "definitions/certificate"
 
   - variable: logsearchapi
     label: Log Search API Configuration


### PR DESCRIPTION
`minioDomain` has a `show_if` that is based on the certificate.
When the variable in the condition is after the condition both fields are hidden in the UI.