### PR TITLE
Storage entry template to reduce boilerplate

### DIFF
--- a/.github/ct-install-config/charts-ct-lint.yaml
+++ b/.github/ct-install-config/charts-ct-lint.yaml
@@ -1,6 +1,6 @@
 remote: origin
 target-branch: master
-helm-extra-args: --timeout 600s --debug
+helm-extra-args: --debug
 lint-conf: .github/ct-install-config/lint-conf.yaml
 chart-yaml-schema: .github/ct-install-config/chart_schema.yaml
 # Check that the version in Chart.yaml is incremented

--- a/.github/ct-install-config/common-ct-lint.yaml
+++ b/.github/ct-install-config/common-ct-lint.yaml
@@ -1,6 +1,6 @@
 remote: origin
 target-branch: master
-helm-extra-args: --timeout 600s --debug
+helm-extra-args: --debug
 lint-conf: .github/ct-install-config/lint-conf.yaml
 chart-yaml-schema: .github/ct-install-config/chart_schema.yaml
 # Check that the version in Chart.yaml is incremented

--- a/.github/workflows/charts_tests.yaml
+++ b/.github/workflows/charts_tests.yaml
@@ -23,7 +23,7 @@ jobs:
           - v3.12.1
     steps:
       - name: Checkout
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
         with:
           # Depth 0 is required for chart-testing to work properly
           fetch-depth: 0
@@ -33,12 +33,12 @@ jobs:
         with:
           version: ${{ matrix.helm-version }}
 
-      - uses: actions/setup-python@2c3dd9e7e29afd70cc0950079bde6c979d1f69f9 # tag=v4
+      - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # tag=v4
         with:
           python-version: "3.10"
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@afea100a513515fbd68b0e72a7bb0ae34cb62aec # tag=v2.3.1
+        uses: helm/chart-testing-action@b43128a8b25298e1e7b043b78ea6613844e079b1 # tag=v2.6.0
 
       - name: Run chart-testing (lint)
         id: lint
@@ -54,13 +54,13 @@ jobs:
       changed_json: ${{ steps.list-changed.outputs.changed_json }}
     steps:
       - name: Checkout
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
         with:
           # Depth 0 is required for chart-testing to work properly
           fetch-depth: 0
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@afea100a513515fbd68b0e72a7bb0ae34cb62aec # tag=v2.3.1
+        uses: helm/chart-testing-action@b43128a8b25298e1e7b043b78ea6613844e079b1 # tag=v2.6.0
 
       - name: List Changed Charts
         id: list-changed
@@ -94,7 +94,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
         with:
           # Depth 0 is required for chart-testing to work properly
           fetch-depth: 0
@@ -104,12 +104,12 @@ jobs:
         with:
           version: ${{ matrix.helm-version }}
 
-      - uses: actions/setup-python@2c3dd9e7e29afd70cc0950079bde6c979d1f69f9 # tag=v4
+      - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # tag=v4
         with:
           python-version: "3.10"
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@afea100a513515fbd68b0e72a7bb0ae34cb62aec # tag=v2.3.1
+        uses: helm/chart-testing-action@b43128a8b25298e1e7b043b78ea6613844e079b1 # tag=v2.6.0
 
       - name: Create k3d cluster - Attempt 1/3
         continue-on-error: true

--- a/.github/workflows/common_library_tests.yaml
+++ b/.github/workflows/common_library_tests.yaml
@@ -22,7 +22,7 @@ jobs:
           - v3.12.1
     steps:
       - name: Checkout
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
         with:
           # Depth 0 is required for chart-testing to work properly
           fetch-depth: 0
@@ -32,12 +32,12 @@ jobs:
         with:
           version: ${{ matrix.helm-version }}
 
-      - uses: actions/setup-python@2c3dd9e7e29afd70cc0950079bde6c979d1f69f9 # tag=v4
+      - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # tag=v4
         with:
           python-version: "3.10"
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@afea100a513515fbd68b0e72a7bb0ae34cb62aec # tag=v2.3.1
+        uses: helm/chart-testing-action@b43128a8b25298e1e7b043b78ea6613844e079b1 # tag=v2.6.0
 
       - name: Run chart-testing (lint)
         id: lint
@@ -60,7 +60,7 @@ jobs:
           - v3.12.1
     steps:
       - name: Checkout
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
         with:
           # Depth 0 is required for chart-testing to work properly
           fetch-depth: 0
@@ -111,7 +111,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
         with:
           # Depth 0 is required for chart-testing to work properly
           fetch-depth: 0
@@ -121,12 +121,12 @@ jobs:
         with:
           version: ${{ matrix.helm-version }}
 
-      - uses: actions/setup-python@2c3dd9e7e29afd70cc0950079bde6c979d1f69f9 # tag=v4
+      - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # tag=v4
         with:
           python-version: "3.10"
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@afea100a513515fbd68b0e72a7bb0ae34cb62aec # tag=v2.3.1
+        uses: helm/chart-testing-action@b43128a8b25298e1e7b043b78ea6613844e079b1 # tag=v2.6.0
 
       - name: Create k3d cluster - Attempt 1/3
         continue-on-error: true

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A library chart for iX Official Catalog
 type: library
-version: 1.2.2
+version: 1.2.3
 appVersion: v1
 annotations:
   title: Common Library Chart

--- a/library/common/templates/app_functions/_postgres.tpl
+++ b/library/common/templates/app_functions/_postgres.tpl
@@ -192,9 +192,7 @@ pgBackup (required): Data persistence configuration for backup
 
 postgresdata:
   enabled: true
-  type: {{ $data.type }}
-  datasetName: {{ $data.datasetName | default "" }}
-  hostPath: {{ $data.hostPath | default "" }}
+  {{- include "ix.v1.common.app.storageOptions" (dict "storage" $data) | nindent 2 }}
   targetSelector:
     postgres:
       postgres:
@@ -203,9 +201,7 @@ postgresdata:
         mountPath: /mnt/directories/postgres_data
 postgresbackup:
   enabled: true
-  type: {{ $backup.type }}
-  datasetName: {{ $backup.datasetName | default "" }}
-  hostPath: {{ $backup.hostPath | default "" }}
+  {{- include "ix.v1.common.app.storageOptions" (dict "storage" $backup) | nindent 2 }}
   targetSelector:
     postgresbackup:
       postgresbackup:

--- a/library/common/templates/app_functions/_storageEntry.tpl
+++ b/library/common/templates/app_functions/_storageEntry.tpl
@@ -60,18 +60,18 @@
     {{- end -}}
   {{- end }}
 
-  type: {{ $storage.type }}
-  size: {{ $size }}
-  hostPath: {{ $hostPath }}
-  datasetName: {{ $datasetName }}
-  readOnly: {{ $readOnly }}
-  server: {{ $server }}
-  share: {{ $share }}
-  domain: {{ $domain }}
-  username: {{ $username }}
-  password: {{ $password }}
-  {{- if eq $storage.type "smb-pv-pvc" }}
-  mountOptions:
-    - key: noperm
-  {{- end }}
+type: {{ $storage.type }}
+size: {{ $size }}
+hostPath: {{ $hostPath }}
+datasetName: {{ $datasetName }}
+readOnly: {{ $readOnly }}
+server: {{ $server }}
+share: {{ $share }}
+domain: {{ $domain }}
+username: {{ $username }}
+password: {{ $password }}
+{{- if eq $storage.type "smb-pv-pvc" }}
+mountOptions:
+  - key: noperm
+{{- end }}
 {{- end -}}

--- a/library/common/templates/app_functions/_storageEntry.tpl
+++ b/library/common/templates/app_functions/_storageEntry.tpl
@@ -1,0 +1,77 @@
+{{/* This is a shim generating yaml that will be passed
+    to the actual templates later on the process.
+    For that reason the validation is minimal as the
+    actual templates will do the validation. */}}
+{{/* Call this template:
+{{ include "ix.v1.common.app.storageOptions" (dict "storage" $storage) }}
+*/}}
+{{- define "ix.v1.common.app.storageOptions" -}}
+  {{- $storage := .storage -}}
+
+  {{- $size := "" -}}
+  {{- $hostPath := "" -}}
+  {{- $datasetName := "" -}}
+  {{- $readOnly := false -}}
+  {{- $server := "" -}}
+  {{- $share := "" -}}
+  {{- $domain := "" -}}
+  {{- $username := "" -}}
+  {{- $password := "" -}}
+
+  {{- if $storage.readOnly -}}
+    {{- $readOnly = true -}}
+  {{- end -}}
+
+  {{/* hostPath */}}
+  {{- if eq $storage.type "hostPath" -}}
+    {{- if not $storage.hostPathConfig -}}
+      {{- fail (printf "Storage Shim - Expected non-empty [hostPathConfig]") -}}
+    {{- end -}}
+
+    {{- if $storage.hostPathConfig.aclEnable -}}
+      {{- $hostPath = $storage.hostPathConfig.acl.path -}}
+    {{- else -}}
+      {{- $hostPath = $storage.hostPathConfig.hostPath -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{/* ixVolume */}}
+  {{- if eq $storage.type "ixVolume" -}}
+    {{- if not $storage.ixVolumeConfig -}}
+      {{- fail (printf "Storage Shim - Expected non-empty [ixVolumeConfig]") -}}
+    {{- end -}}
+
+    {{- $datasetName = $storage.ixVolumeConfig.datasetName -}}
+  {{- end -}}
+
+  {{/* SMB Share */}}
+  {{- if eq $storage.type "smb-pv-pvc" -}}
+    {{- if not $storage.smbConfig -}}
+      {{- fail (printf "Storage Shim - Expected non-empty [smbConfig]") -}}
+    {{- end -}}
+
+    {{- $server = $storage.smbConfig.server -}}
+    {{- $share = $storage.smbConfig.share -}}
+    {{- $domain = $storage.smbConfig.domain -}}
+    {{- $username = $storage.smbConfig.username -}}
+    {{- $password = $storage.smbConfig.password -}}
+    {{- if $storage.smbConfig.size -}}
+      {{- $size = (printf "%vGi" $storage.smbConfig.size) -}}
+    {{- end -}}
+  {{- end }}
+
+  type: {{ $storage.type }}
+  size: {{ $size }}
+  hostPath: {{ $hostPath }}
+  datasetName: {{ $datasetName }}
+  readOnly: {{ $readOnly }}
+  server: {{ $server }}
+  share: {{ $share }}
+  domain: {{ $domain }}
+  username: {{ $username }}
+  password: {{ $password }}
+  {{- if eq $storage.type "smb-pv-pvc" }}
+  mountOptions:
+    - key: noperm
+  {{- end }}
+{{- end -}}


### PR DESCRIPTION
Adds a template for the storage entry to use in apps, this will allow to easily add extra fields in the future, with only adapting the questions on the apps

Also bumps CI deps

---

New structure for hostPath and ixVolume

Also readOnly is added as option for all storage types (hostPath, ixVolume, smb).
This option is added only for additionalStorages.

```yaml
appStorage:
  additionalStorages:
   # hosPath ACL true
    - type: hostPath
      readOnly: true
      mountPath: /data1
      hostPathConfig:
        aclEnable: true
        acl:
          path: /mnt/pool/data1
  
    # hosPath ACL false
    - type: hostPath
      readOnly: true
      mountPath: /data2
      hostPathConfig:
        aclEnable: false
        hostPath: /mnt/pool/data2
  
    # ixVol ACL true
    - type: ixVolume
      mountPath: /data3
      ixVolumeConfig:
        datasetName: data3
        aclEnable: true
  
    # ixVol ACL false
    - type: ixVolume
      mountPath: /data4
      ixVolumeConfig:
        datasetName: data4
        aclEnable: false

    # SMB (no acl here)
    - type: smb-pv-pvc
      mountPath: /data5
      smbConfig:
        server: 10.0.0.1
        share: share-name
        domain: domain
        username: username
        password: password
        size: 1
```