### PR TITLE
Add readOnly option to Immich's additionalLibraries

### DIFF
--- a/community/immich/1.0.33/ci/extra-values.yaml
+++ b/community/immich/1.0.33/ci/extra-values.yaml
@@ -17,6 +17,7 @@ immichStorage:
   additionalLibraries:
     - hostPath: /mnt/{{ .Release.Name }}/additionalLibrary1
     - hostPath: /mnt/{{ .Release.Name }}/additionalLibrary2
+      readOnly: true
   pgData:
     type: hostPath
     hostPath: /mnt/{{ .Release.Name }}/pgData

--- a/community/immich/1.0.33/questions.yaml
+++ b/community/immich/1.0.33/questions.yaml
@@ -295,6 +295,12 @@ questions:
                       schema:
                         type: hostpath
                         required: true
+                    - variable: readOnly
+                      label: "Read Only"
+                      description: "Mount host path in read-only mode"
+                      schema:
+                        type: boolean
+                        default: false
         - variable: pgData
           label: Immich Postgres Data Storage
           description: The path to store Immich Postgres Data.

--- a/community/immich/1.0.33/templates/_persistence.tpl
+++ b/community/immich/1.0.33/templates/_persistence.tpl
@@ -71,9 +71,15 @@ persistence:
       server:
         server:
           mountPath: {{ $storage.hostPath }}
+          {{ if $storage.readOnly }}
+          readOnly: {{ $storage.readOnly }}
+          {{ end }}
       microservices:
         microservices:
           mountPath: {{ $storage.hostPath }}
+          {{ if $storage.readOnly }}
+          readOnly: {{ $storage.readOnly }}
+          {{ end }}
   {{- end }}
   {{/* Caches */}}
   microcache:


### PR DESCRIPTION
It would be helpful if `additionalLibraries` for Immich app allowed for read-only mounts of host paths. These are frequently used for [External Libraries](https://immich.app/docs/features/libraries#external-libraries)  and mounting them in read-only mode is a good practice.

<img width="469" alt="Screenshot 2023-11-06 at 00 53 37" src="https://github.com/truenas/charts/assets/85191/59ee314e-a785-49d1-b4e8-000e1ab717c0">
