### PR TITLE
Show a message when user tries to upgrade app with db from a stopped state

### DIFF
--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A library chart for iX Official Catalog
 type: library
-version: 1.2.1
+version: 1.2.2
 appVersion: v1
 annotations:
   title: Common Library Chart

--- a/library/common/templates/app_functions/_mariadb.tpl
+++ b/library/common/templates/app_functions/_mariadb.tpl
@@ -70,6 +70,11 @@ backupChownMode (optional): Whether to chown the backup directory or
   {{- if $ixChartContext.isUpgrade -}}
     {{- $enableBackupJob = true -}}
   {{- end -}}
+  {{- if hasKey $ixChartContext "isStopped" -}}
+    {{- if $ixChartContext.isStopped -}}
+      {{- fail "Application must be running before upgrade. This is to ensure the database backup will be able to complete." -}}
+    {{- end -}}
+  {{- end -}}
 {{- else -}}
   {{/*
     If the key is not present in ixChartContext,

--- a/library/common/templates/app_functions/_mariadb.tpl
+++ b/library/common/templates/app_functions/_mariadb.tpl
@@ -69,10 +69,10 @@ backupChownMode (optional): Whether to chown the backup directory or
 {{- if hasKey $ixChartContext "isUpgrade" -}}
   {{- if $ixChartContext.isUpgrade -}}
     {{- $enableBackupJob = true -}}
-  {{- end -}}
-  {{- if hasKey $ixChartContext "isStopped" -}}
-    {{- if $ixChartContext.isStopped -}}
-      {{- fail "Application must be running before upgrade. This is to ensure the database backup will be able to complete." -}}
+    {{- if hasKey $ixChartContext "isStopped" -}}
+      {{- if $ixChartContext.isStopped -}}
+        {{- fail "Application must be running before upgrade. This is to ensure the database backup will be able to complete." -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 {{- else -}}

--- a/library/common/templates/app_functions/_postgres.tpl
+++ b/library/common/templates/app_functions/_postgres.tpl
@@ -74,10 +74,10 @@ backupChownMode (optional): Whether to chown the backup directory or
   {{- if hasKey $ixChartContext "isUpgrade" -}}
     {{- if $ixChartContext.isUpgrade -}}
       {{- $enableBackupJob = true -}}
-    {{- end -}}
-    {{- if hasKey $ixChartContext "isStopped" -}}
-      {{- if $ixChartContext.isStopped -}}
-        {{- fail "Application must be running before upgrade. This is to ensure the database backup will be able to complete." -}}
+      {{- if hasKey $ixChartContext "isStopped" -}}
+        {{- if $ixChartContext.isStopped -}}
+          {{- fail "Application must be running before upgrade. This is to ensure the database backup will be able to complete." -}}
+        {{- end -}}
       {{- end -}}
     {{- end -}}
   {{- else -}}

--- a/library/common/templates/app_functions/_postgres.tpl
+++ b/library/common/templates/app_functions/_postgres.tpl
@@ -75,6 +75,11 @@ backupChownMode (optional): Whether to chown the backup directory or
     {{- if $ixChartContext.isUpgrade -}}
       {{- $enableBackupJob = true -}}
     {{- end -}}
+    {{- if hasKey $ixChartContext "isStopped" -}}
+      {{- if $ixChartContext.isStopped -}}
+        {{- fail "Application must be running before upgrade. This is to ensure the database backup will be able to complete." -}}
+      {{- end -}}
+    {{- end -}}
   {{- else -}}
     {{/* If the key is not present in ixChartContext, means we
       are outside SCALE (Probably CI), let upgrade job run */}}


### PR DESCRIPTION
Closes #1687 

If a user tries to upgrade an app with database from a stopped state, the DB will not be reachable, so we should block **early** the upgrade, because the backup job will not be able to complete and will result to a timeout.

Alternatives are: 
- Skip the backup completely.
- Start the database inside the backup job. (I 'm not a fan of spinning processes in the background in the same container.)

---

https://ixsystems.atlassian.net/browse/TNCHARTS-324