### PR TITLE
Update variable used in TRANSMISSION__DOWNLOAD_DIR

### DIFF
--- a/community/transmission/1.2.1/templates/_configuration.tpl
+++ b/community/transmission/1.2.1/templates/_configuration.tpl
@@ -7,7 +7,7 @@ configmap:
       TRANSMISSION__RPC_BIND_ADDRESS: "0.0.0.0"
       TRANSMISSION__RPC_PORT: {{ .Values.transmissionNetwork.webPort | quote }}
       TRANSMISSION__PEER_PORT: {{ .Values.transmissionNetwork.peerPort | quote }}
-      TRANSMISSION__DOWNLOAD_DIR: {{ .Values.transmissionStorage.downloadDir | default "/downloads/complete" }}
+      TRANSMISSION__DOWNLOAD_DIR: {{ .Values.transmissionStorage.downloadsDir | default "/downloads/complete" }}
       TRANSMISSION__INCOMPLETE_DIR_ENABLED: {{ .Values.transmissionStorage.enableIncompleteDir | quote }}
       {{- if .Values.transmissionStorage.enableIncompleteDir }}
       TRANSMISSION__INCOMPLETE_DIR: {{ .Values.transmissionStorage.incompleteDir | default "/downloads/incomplete" }}


### PR DESCRIPTION
It appears that the setting for the completed downloads is not being set correctly, no matter what you set the directory to be in TrueNAS, it will always revert to `/downloads/complete`

I suspect this to be due to a mismatch in the name of the variable between `questions.yaml` and `_configuration.tpl`

I have changed the variable from `downloadDir` to `downloadsDir` in `_configuration.tpl`, so that it matches what is defined in `questions.yaml` and it then should correctly pickup on the user defined configuration in TrueNAS