### PR TITLE
fix minio trying to access appVolumeMounts in distributed mode

### DIFF
--- a/library/ix-dev/charts/minio/Chart.yaml
+++ b/library/ix-dev/charts/minio/Chart.yaml
@@ -3,7 +3,7 @@ description: High Performance, Kubernetes Native Object Storage
 annotations:
   title: MinIO
 type: application
-version: 1.7.20
+version: 1.7.21
 apiVersion: v2
 appVersion: '2023-03-13'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/minio/templates/deployment.yaml
+++ b/library/ix-dev/charts/minio/templates/deployment.yaml
@@ -49,7 +49,11 @@ spec:
         - name: {{ .Chart.Name }}
           {{ include "common.resources.limitation" . | nindent 10 }}
           {{ include "common.containers.imageConfig" .Values.image | nindent 10 }}
+          {{ if hasKey .Values "appVolumeMounts" }}
           volumeMounts: {{ include "common.storage.configureAppVolumeMountsInContainer" .Values | nindent 12 }}
+          {{ else }}
+          volumeMounts:
+          {{ end }}
           {{- include "minio.tlsKeysVolumeMount" . | nindent 12 }}
           {{ range $index, $hostPathConfiguration := .Values.extraAppVolumeMounts }}
             - name: extrappvolume-{{ $index }}
@@ -114,7 +118,11 @@ spec:
             {{ end }}
             {{ include "common.containers.environmentVariables" (dict "environmentVariables" $envList) | nindent 12 }}
 {{ include "common.networking.dnsConfiguration" .Values | nindent 6 }}
+      {{ if hasKey .Values "appVolumeMounts" }}
       volumes: {{ include "common.storage.configureAppVolumes" .Values | nindent 8 }}
+      {{ else }}
+      volumes:
+      {{ end }}
       {{- include "minio.tlsKeysVolume" . | nindent 8 }}
       {{ range $index, $hostPathConfiguration := .Values.extraAppVolumeMounts }}
         - name: extrappvolume-{{ $index }}


### PR DESCRIPTION
When `distributedMode` is enabled, appVolumeMounts are hidden and not used.
But it fails a check from the old common lib.

- Added a check that the dict exists before trying to validate it / use it

https://ixsystems.atlassian.net/browse/NAS-125206