### PR TITLE
update kavita image repo

### DIFF
--- a/library/ix-dev/community/kavita/Chart.yaml
+++ b/library/ix-dev/community/kavita/Chart.yaml
@@ -3,9 +3,9 @@ description: Kavita is a fast, feature rich, cross platform reading server.
 annotations:
   title: Kavita
 type: application
-version: 1.1.3
+version: 1.1.4
 apiVersion: v2
-appVersion: 0.7.8
+appVersion: 0.7.10
 kubeVersion: '>=1.16.0-0'
 maintainers:
   - name: truenas

--- a/library/ix-dev/community/kavita/values.yaml
+++ b/library/ix-dev/community/kavita/values.yaml
@@ -1,7 +1,7 @@
 image:
-  repository: kizaing/kavita
+  repository: jvmilazz0/kavita
   pullPolicy: IfNotPresent
-  tag: 0.7.8
+  tag: 0.7.10
 
 resources:
   limits:


### PR DESCRIPTION
Kavita's images have been moved from kizaing/kavita to jvmilazz0/kavita. This PR updates the repository and tag to the most recent. 

[source](https://github.com/Kareadita/Kavita/releases/tag/v0.7.9) (Under "Important Announcements")