### PR TITLE
Photoprism: Add 'Host Network'

### DIFF
--- a/library/ix-dev/charts/photoprism/Chart.yaml
+++ b/library/ix-dev/charts/photoprism/Chart.yaml
@@ -3,7 +3,7 @@ description: AI-powered app for browsing, organizing & sharing your photo collec
 annotations:
   title: PhotoPrism
 type: application
-version: 1.0.32
+version: 1.1.0
 apiVersion: v2
 appVersion: '231021'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/photoprism/questions.yaml
+++ b/library/ix-dev/charts/photoprism/questions.yaml
@@ -23,6 +23,15 @@ portals:
     path: "/"
 
 questions:
+  - variable: host_network
+    group: Networking
+    label: Host Network
+    description: |
+      Bind to the host network. It's recommended to keep this disabled but may be needed for photoprism to be reachable from a hostNetworked VPN.</br>
+    schema:
+      type: boolean
+      default: false
+
   - variable: web_port
     label: "Web Port for photo prism"
     group: Networking

--- a/library/ix-dev/charts/photoprism/templates/deployment.yaml
+++ b/library/ix-dev/charts/photoprism/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         {{- include "common.labels.selectorLabels" . | nindent 8 }}
       annotations: {{ include "common.annotations" . | nindent 8 }}
     spec:
-      hostNetwork: false
+      hostNetwork: {{ .Values.host_network }}
       {{- if hasKey .Values "global" }}
         {{- if hasKey .Values.global "ixChartContext" }}
           {{- if .Values.global.ixChartContext.addNvidiaRuntimeClass }}

--- a/library/ix-dev/charts/photoprism/templates/deployment.yaml
+++ b/library/ix-dev/charts/photoprism/templates/deployment.yaml
@@ -46,11 +46,11 @@ spec:
           {{ end }}
           ports:
             - name: web
-              containerPort: 2342
+              containerPort: {{ .Values.web_port }}
           readinessProbe:
             httpGet:
               path: /
-              port: 2342
+              port: {{ .Values.web_port }}
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
@@ -59,7 +59,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: 2342
+              port: {{ .Values.web_port }}
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
@@ -68,7 +68,7 @@ spec:
           startupProbe:
             httpGet:
               path: /
-              port: 2342
+              port: {{ .Values.web_port }}
             initialDelaySeconds: 10
             periodSeconds: 5
             timeoutSeconds: 2
@@ -77,6 +77,7 @@ spec:
           env:
             {{ $secretName := (include "common.names.fullname" .) }}
             {{ $envList := (default list .Values.environmentVariables) }}
+            {{ $envList = mustAppend $envList (dict "name" "PHOTOPRISM_HTTP_PORT" "value" .Values.web_port) }}
             {{ $envList = mustAppend $envList (dict "name" "PHOTOPRISM_ADMIN_PASSWORD" "valueFromSecret" true "secretName" $secretName "secretKey" "password") }}
             {{ if .Values.public }}
             {{ $envList = mustAppend $envList (dict "name" "PHOTOPRISM_PUBLIC" "value" "true") }}

--- a/library/ix-dev/charts/photoprism/templates/service.yaml
+++ b/library/ix-dev/charts/photoprism/templates/service.yaml
@@ -2,7 +2,7 @@
 {{ $selectors = mustAppend $selectors (dict "key" "app" "value" (include "common.names.name" .) ) }}
 {{ $selectors = mustAppend $selectors (dict "key" "release" "value" .Release.Name ) }}
 {{ $ports := list }}
-{{ $ports = mustAppend $ports (dict "name" "web" "port" .Values.web_port "nodePort" .Values.web_port "targetPort" 2342) }}
+{{ $ports = mustAppend $ports (dict "name" "web" "port" .Values.web_port "nodePort" .Values.web_port "targetPort" .Values.web_port) }}
 {{ $params := . }}
 {{ $_ := set $params "commonService" (dict "type" "NodePort" "ports" $ports ) }}
 {{ $_1 := set .Values "extraSelectorLabels" $selectors }}


### PR DESCRIPTION
I've added a host network checkbox to the photoprism chart.
This makes photoprism reachable from tailscale, which I've also installed with host network enabled.

![image](https://github.com/truenas/charts/assets/5539202/61c102f1-68b3-4bf8-b4ba-e34d28289a82)

