### PR TITLE
fix pihole upgrade_strategy

### DIFF
--- a/library/ix-dev/charts/pihole/upgrade_strategy
+++ b/library/ix-dev/charts/pihole/upgrade_strategy
@@ -11,7 +11,7 @@ RE_STABLE_VERSION = re.compile(r'\d+\.\d+\.\d+')
 
 def newer_mapping(image_tags):
     key = list(image_tags.keys())[0]
-    tags = {t for t in image_tags[key] if RE_STABLE_VERSION.fullmatch(t)}
+    tags = {t: t for t in image_tags[key] if RE_STABLE_VERSION.fullmatch(t)}
     version = semantic_versioning(list(tags))
     if not version:
         return {}


### PR DESCRIPTION
Fixes this:

```
root@b376dc33f6d9:/workspace# python3 upgrade_strategy 
Traceback (most recent call last):
  File "/workspace/upgrade_strategy", line 34, in <module>
    print(json.dumps(newer_mapping(versions_json)))
  File "/workspace/upgrade_strategy", line 16, in newer_mapping
    print(tags[version])
TypeError: 'set' object is not subscriptable
```

Output now looks like this:

```
root@b376dc33f6d9:/workspace# python3 upgrade_strategy 
{"tags": {"image": "2023.11.0"}, "app_version": "2023.11.0"}
```