### PR TITLE
mealie - bump version

### DIFF
--- a/library/ix-dev/community/mealie/Chart.lock
+++ b/library/ix-dev/community/mealie/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: file://../../../common
   version: 1.2.4
 digest: sha256:47ebfd41bc2ac33ab6989e7bd4d1d3aea662365fffa8b525a24cc56a2a35c174
-generated: "2023-12-15T18:22:58.138621992+02:00"
+generated: "2023-12-11T16:07:50.550688546+02:00"

--- a/library/ix-dev/community/mealie/Chart.yaml
+++ b/library/ix-dev/community/mealie/Chart.yaml
@@ -5,7 +5,7 @@ annotations:
 type: application
 version: 1.0.2
 apiVersion: v2
-appVersion: latest
+appVersion: v1.0.0-RC2
 kubeVersion: '>=1.16.0-0'
 maintainers:
   - name: truenas

--- a/library/ix-dev/community/mealie/Chart.yaml
+++ b/library/ix-dev/community/mealie/Chart.yaml
@@ -3,7 +3,7 @@ description: Mealie is a self-hosted recipe manager and meal planner
 annotations:
   title: Mealie
 type: application
-version: 1.0.2
+version: 1.0.3
 apiVersion: v2
 appVersion: v1.0.0-RC2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/mealie/templates/_mealie.tpl
+++ b/library/ix-dev/community/mealie/templates/_mealie.tpl
@@ -49,6 +49,11 @@ workload:
                 - python
                 - /app/mealie/scripts/healthcheck.py
       initContainers:
-      {{- include "ix.v1.common.app.postgresWait" (dict "name" "01-postgres-wait"
+      {{- include "ix.v1.common.app.permissions" (dict "containerName" "01-permissions"
+                                                        "UID" .Values.mealieRunAs.user
+                                                        "GID" .Values.mealieRunAs.group
+                                                        "mode" "check"
+                                                        "type" "install") | nindent 8 }}
+      {{- include "ix.v1.common.app.postgresWait" (dict "name" "02-postgres-wait"
                                                         "secretName" "postgres-creds") | nindent 8 }}
 {{- end -}}

--- a/library/ix-dev/community/mealie/templates/_persistence.tpl
+++ b/library/ix-dev/community/mealie/templates/_persistence.tpl
@@ -7,6 +7,10 @@ persistence:
       mealie:
         mealie:
           mountPath: /app/data
+        {{- if eq .Values.mealieStorage.data.type "ixVolume" }}
+        01-permissions:
+          mountPath: /mnt/directories/data
+        {{- end }}
   tmp:
     enabled: true
     type: emptyDir
@@ -22,6 +26,10 @@ persistence:
       mealie:
         mealie:
           mountPath: {{ $storage.mountPath }}
+        {{- if eq .Values.mealieStorage.data.type "ixVolume" }}
+        01-permissions:
+          mountPath: /mnt/directories{{ $storage.mountPath }}
+        {{- end }}
   {{- end -}}
 
   {{- include "ix.v1.common.app.postgresPersistence"

--- a/library/ix-dev/community/mealie/templates/_persistence.tpl
+++ b/library/ix-dev/community/mealie/templates/_persistence.tpl
@@ -7,7 +7,8 @@ persistence:
       mealie:
         mealie:
           mountPath: /app/data
-        {{- if eq .Values.mealieStorage.data.type "ixVolume" }}
+        {{- if and (eq .Values.mealieStorage.data.type "ixVolume")
+                  (not (.Values.mealieStorage.data.ixVolumeConfig | default dict).aclEnable) }}
         01-permissions:
           mountPath: /mnt/directories/data
         {{- end }}
@@ -26,7 +27,7 @@ persistence:
       mealie:
         mealie:
           mountPath: {{ $storage.mountPath }}
-        {{- if eq .Values.mealieStorage.data.type "ixVolume" }}
+        {{- if and (eq $storage.type "ixVolume") (not ($storage.ixVolumeConfig | default dict).aclEnable) }}
         01-permissions:
           mountPath: /mnt/directories{{ $storage.mountPath }}
         {{- end }}

--- a/library/ix-dev/community/mealie/values.yaml
+++ b/library/ix-dev/community/mealie/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: ghcr.io/mealie-recipes/mealie
   pullPolicy: IfNotPresent
-  tag: v1.0.0-RC1.1
+  tag: v1.0.0-RC2
 
 resources:
   limits:


### PR DESCRIPTION
CI Fails are expected.
Its because the way it tests the upgrade, (it tries to use the old values with new templates).
Which in our case does not happen on real systems.