### PR TITLE
fix permission on ixVolumes on initial install, when acls are not enabled

### DIFF
--- a/library/ix-dev/charts/elastic-search/Chart.yaml
+++ b/library/ix-dev/charts/elastic-search/Chart.yaml
@@ -4,7 +4,7 @@ description: Elasticsearch is the distributed, RESTful search and analytics engi
 annotations:
   title: Elastic Search
 type: application
-version: 1.1.3
+version: 1.1.4
 apiVersion: v2
 appVersion: 8.11.3
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/prometheus/Chart.yaml
+++ b/library/ix-dev/charts/prometheus/Chart.yaml
@@ -3,7 +3,7 @@ description: The Prometheus monitoring system and time series database.
 annotations:
   title: Prometheus
 type: application
-version: 1.1.2
+version: 1.1.3
 apiVersion: v2
 appVersion: v2.48.1
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/bazarr/Chart.yaml
+++ b/library/ix-dev/community/bazarr/Chart.yaml
@@ -3,7 +3,7 @@ description: Bazarr is a companion application to Sonarr and Radarr. It manages 
 annotations:
   title: Bazarr
 type: application
-version: 1.2.2
+version: 1.2.3
 apiVersion: v2
 appVersion: 1.4.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/bazarr/templates/_bazarr.tpl
+++ b/library/ix-dev/community/bazarr/templates/_bazarr.tpl
@@ -42,4 +42,10 @@ workload:
               type: http
               port: "{{ .Values.bazarrNetwork.webPort }}"
               path: /api/swagger.json
+      initContainers:
+      {{- include "ix.v1.common.app.permissions" (dict "containerName" "01-permissions"
+                                                        "UID" .Values.bazarrRunAs.user
+                                                        "GID" .Values.bazarrRunAs.group
+                                                        "mode" "check"
+                                                        "type" "install") | nindent 8 }}
 {{- end -}}

--- a/library/ix-dev/community/briefkasten/Chart.yaml
+++ b/library/ix-dev/community/briefkasten/Chart.yaml
@@ -3,7 +3,7 @@ description: Briefkasten is a self hosted bookmarking app
 annotations:
   title: Briefkasten
 type: application
-version: 1.2.1
+version: 1.2.2
 apiVersion: v2
 appVersion: latest
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/briefkasten/templates/_persistence.tpl
+++ b/library/ix-dev/community/briefkasten/templates/_persistence.tpl
@@ -10,32 +10,19 @@ persistence:
   {{- range $idx, $storage := .Values.briefkastenStorage.additionalStorages }}
   {{ printf "briefkasten-%v:" (int $idx) }}
     enabled: true
-    {{- include "briefkasten.storage.ci.migration" (dict "storage" $storage) }}
     {{- include "ix.v1.common.app.storageOptions" (dict "storage" $storage) | nindent 4 }}
     targetSelector:
       briefkasten:
         briefkasten:
           mountPath: {{ $storage.mountPath }}
-        {{- if eq $storage.type "ixVolume" }}
+        {{- if and (eq $storage.type "ixVolume") (not ($storage.ixVolumeConfig | default dict).aclEnable) }}
         01-permissions:
           mountPath: /mnt/directories{{ $storage.mountPath }}
         {{- end }}
   {{- end -}}
 
-  {{- include "briefkasten.storage.ci.migration" (dict "storage" .Values.briefkastenStorage.pgData) }}
-  {{- include "briefkasten.storage.ci.migration" (dict "storage" .Values.briefkastenStorage.pgBackup) }}
   {{- include "ix.v1.common.app.postgresPersistence"
       (dict "pgData" .Values.briefkastenStorage.pgData
             "pgBackup" .Values.briefkastenStorage.pgBackup
       ) | nindent 2 }}
-{{- end -}}
-
-{{/* TODO: Remove on the next version bump, eg 1.2.0+ */}}
-{{- define "briefkasten.storage.ci.migration" -}}
-  {{- $storage := .storage -}}
-
-  {{- if $storage.hostPath -}}
-    {{- $_ := set $storage "hostPathConfig" dict -}}
-    {{- $_ := set $storage.hostPathConfig "hostPath" $storage.hostPath -}}
-  {{- end -}}
 {{- end -}}

--- a/library/ix-dev/community/jellyfin/Chart.yaml
+++ b/library/ix-dev/community/jellyfin/Chart.yaml
@@ -4,7 +4,7 @@ description: Jellyfin is a Free Software Media System that puts you in control o
 annotations:
   title: Jellyfin
 type: application
-version: 1.2.1
+version: 1.2.2
 apiVersion: v2
 appVersion: 10.8.13
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/lidarr/Chart.yaml
+++ b/library/ix-dev/community/lidarr/Chart.yaml
@@ -3,7 +3,7 @@ description: Lidarr is a music collection manager for Usenet and BitTorrent user
 annotations:
   title: Lidarr
 type: application
-version: 1.2.3
+version: 1.2.4
 apiVersion: v2
 appVersion: 2.0.7.3849
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/prowlarr/Chart.yaml
+++ b/library/ix-dev/community/prowlarr/Chart.yaml
@@ -4,7 +4,7 @@ description: Prowlarr is an indexer manager/proxy to integrate with your various
 annotations:
   title: Prowlarr
 type: application
-version: 1.2.2
+version: 1.2.3
 apiVersion: v2
 appVersion: 1.11.1.4146
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/prowlarr/templates/_persistence.tpl
+++ b/library/ix-dev/community/prowlarr/templates/_persistence.tpl
@@ -2,12 +2,16 @@
 persistence:
   config:
     enabled: true
-    {{- include "prowlarr.storage.ci.migration" (dict "storage" .Values.prowlarrStorage.config) }}
     {{- include "ix.v1.common.app.storageOptions" (dict "storage" .Values.prowlarrStorage.config) | nindent 4 }}
     targetSelector:
       prowlarr:
         prowlarr:
           mountPath: /config
+        {{- if and (eq .Values.prowlarrStorage.config.type "ixVolume")
+                  (not (.Values.prowlarrStorage.config.ixVolumeConfig | default dict).aclEnable) }}
+        01-permissions:
+          mountPath: /mnt/directories/config
+        {{- end }}
   tmp:
     enabled: true
     type: emptyDir
@@ -18,21 +22,14 @@ persistence:
   {{- range $idx, $storage := .Values.prowlarrStorage.additionalStorages }}
   {{ printf "prowlarr-%v:" (int $idx) }}
     enabled: true
-    {{- include "prowlarr.storage.ci.migration" (dict "storage" $storage) }}
     {{- include "ix.v1.common.app.storageOptions" (dict "storage" $storage) | nindent 4 }}
     targetSelector:
       prowlarr:
         prowlarr:
           mountPath: {{ $storage.mountPath }}
+        {{- if and (eq $storage.type "ixVolume") (not ($storage.ixVolumeConfig | default dict).aclEnable) }}
+        01-permissions:
+          mountPath: /mnt/directories{{ $storage.mountPath }}
+        {{- end }}
   {{- end }}
-{{- end -}}
-
-{{/* TODO: Remove on the next version bump, eg 1.2.0+ */}}
-{{- define "prowlarr.storage.ci.migration" -}}
-  {{- $storage := .storage -}}
-
-  {{- if $storage.hostPath -}}
-    {{- $_ := set $storage "hostPathConfig" dict -}}
-    {{- $_ := set $storage.hostPathConfig "hostPath" $storage.hostPath -}}
-  {{- end -}}
 {{- end -}}

--- a/library/ix-dev/community/prowlarr/templates/_prowlarr.tpl
+++ b/library/ix-dev/community/prowlarr/templates/_prowlarr.tpl
@@ -40,4 +40,10 @@ workload:
               type: http
               port: "{{ .Values.prowlarrNetwork.webPort }}"
               path: /ping
+      initContainers:
+      {{- include "ix.v1.common.app.permissions" (dict "containerName" "01-permissions"
+                                                        "UID" .Values.prowlarrRunAs.user
+                                                        "GID" .Values.prowlarrRunAs.group
+                                                        "mode" "check"
+                                                        "type" "install") | nindent 8 }}
 {{- end -}}

--- a/library/ix-dev/community/qbittorrent/Chart.yaml
+++ b/library/ix-dev/community/qbittorrent/Chart.yaml
@@ -3,7 +3,7 @@ description: The qBittorrent project aims to provide an open-source software alt
 annotations:
   title: qBittorrent
 type: application
-version: 1.2.2
+version: 1.2.3
 apiVersion: v2
 appVersion: 4.6.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/radarr/Chart.yaml
+++ b/library/ix-dev/community/radarr/Chart.yaml
@@ -3,7 +3,7 @@ description: Radarr is a movie collection manager for Usenet and BitTorrent user
 annotations:
   title: Radarr
 type: application
-version: 1.2.2
+version: 1.2.3
 apiVersion: v2
 appVersion: 5.1.3.8246
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/readarr/Chart.yaml
+++ b/library/ix-dev/community/readarr/Chart.yaml
@@ -4,7 +4,7 @@ description: Readarr is an ebook and audiobook collection manager for Usenet and
 annotations:
   title: Readarr
 type: application
-version: 1.2.0
+version: 1.2.1
 apiVersion: v2
 appVersion: 0.3.11.2319
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/readarr/templates/_persistence.tpl
+++ b/library/ix-dev/community/readarr/templates/_persistence.tpl
@@ -2,13 +2,13 @@
 persistence:
   config:
     enabled: true
-    {{- include "readarr.storage.ci.migration" (dict "storage" .Values.readarrStorage.config) }}
     {{- include "ix.v1.common.app.storageOptions" (dict "storage" .Values.readarrStorage.config) | nindent 4 }}
     targetSelector:
       readarr:
         readarr:
           mountPath: /config
-        {{- if eq .Values.readarrStorage.config.type "ixVolume" }}
+        {{- if and (eq .Values.readarrStorage.config.type "ixVolume")
+                  (not (.Values.readarrStorage.config.ixVolumeConfig | default dict).aclEnable) }}
         01-permissions:
           mountPath: /mnt/directories/config
         {{- end }}
@@ -22,25 +22,14 @@ persistence:
   {{- range $idx, $storage := .Values.readarrStorage.additionalStorages }}
   {{ printf "readarr-%v:" (int $idx) }}
     enabled: true
-    {{- include "readarr.storage.ci.migration" (dict "storage" $storage) }}
     {{- include "ix.v1.common.app.storageOptions" (dict "storage" $storage) | nindent 4 }}
     targetSelector:
       readarr:
         readarr:
           mountPath: {{ $storage.mountPath }}
-        {{- if eq $storage.type "ixVolume" }}
+        {{- if and (eq $storage.type "ixVolume") (not ($storage.ixVolumeConfig | default dict).aclEnable) }}
         01-permissions:
           mountPath: /mnt/directories{{ $storage.mountPath }}
         {{- end }}
   {{- end }}
-{{- end -}}
-
-{{/* TODO: Remove on the next version bump, eg 1.2.0+ */}}
-{{- define "readarr.storage.ci.migration" -}}
-  {{- $storage := .storage -}}
-
-  {{- if $storage.hostPath -}}
-    {{- $_ := set $storage "hostPathConfig" dict -}}
-    {{- $_ := set $storage.hostPathConfig "hostPath" $storage.hostPath -}}
-  {{- end -}}
 {{- end -}}

--- a/library/ix-dev/community/sonarr/Chart.yaml
+++ b/library/ix-dev/community/sonarr/Chart.yaml
@@ -3,7 +3,7 @@ description: Sonarr is a PVR for Usenet and BitTorrent users.
 annotations:
   title: Sonarr
 type: application
-version: 1.2.2
+version: 1.2.3
 apiVersion: v2
 appVersion: '3.0.10.1567'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/sonarr/templates/_sonarr.tpl
+++ b/library/ix-dev/community/sonarr/templates/_sonarr.tpl
@@ -40,7 +40,12 @@ workload:
               type: http
               port: "{{ .Values.sonarrNetwork.webPort }}"
               path: /ping
-
+      initContainers:
+      {{- include "ix.v1.common.app.permissions" (dict "containerName" "01-permissions"
+                                                        "UID" .Values.sonarrRunAs.user
+                                                        "GID" .Values.sonarrRunAs.group
+                                                        "mode" "check"
+                                                        "type" "install") | nindent 8 }}
 {{/* Service */}}
 service:
   sonarr:
@@ -60,12 +65,16 @@ service:
 persistence:
   config:
     enabled: true
-    {{- include "sonarr.storage.ci.migration" (dict "storage" .Values.sonarrStorage.config) }}
     {{- include "ix.v1.common.app.storageOptions" (dict "storage" .Values.sonarrStorage.config) | nindent 4 }}
     targetSelector:
       sonarr:
         sonarr:
           mountPath: /config
+        {{- if and (eq .Values.sonarrStorage.config.type "ixVolume")
+                  (not (.Values.sonarrStorage.config.ixVolumeConfig | default dict).aclEnable) }}
+        01-permissions:
+          mountPath: /mnt/directories/config
+        {{- end }}
   tmp:
     enabled: true
     type: emptyDir
@@ -76,21 +85,14 @@ persistence:
   {{- range $idx, $storage := .Values.sonarrStorage.additionalStorages }}
   {{ printf "sonarr-%v:" (int $idx) }}
     enabled: true
-    {{- include "sonarr.storage.ci.migration" (dict "storage" $storage) }}
     {{- include "ix.v1.common.app.storageOptions" (dict "storage" $storage) | nindent 4 }}
     targetSelector:
       sonarr:
         sonarr:
           mountPath: {{ $storage.mountPath }}
+        {{- if and (eq $storage.type "ixVolume") (not ($storage.ixVolumeConfig | default dict).aclEnable) }}
+        01-permissions:
+          mountPath: /mnt/directories{{ $storage.mountPath }}
+        {{- end }}
   {{- end }}
-{{- end -}}
-
-{{/* TODO: Remove on the next version bump, eg 1.2.0+ */}}
-{{- define "sonarr.storage.ci.migration" -}}
-  {{- $storage := .storage -}}
-
-  {{- if $storage.hostPath -}}
-    {{- $_ := set $storage "hostPathConfig" dict -}}
-    {{- $_ := set $storage.hostPathConfig "hostPath" $storage.hostPath -}}
-  {{- end -}}
 {{- end -}}


### PR DESCRIPTION
- Adds init container that will run on the first installation which will chown any ixVolumes created  as discussed [here](https://github.com/truenas/charts/issues/1880#issuecomment-1854228588)
- Removes an oneshot migration that was added for **ci** only values