### PR TITLE
fix(common/rbac): adds resourceNames field

### DIFF
--- a/library/common-test/tests/rbac/data_test.yaml
+++ b/library/common-test/tests/rbac/data_test.yaml
@@ -32,6 +32,8 @@ tests:
                 - "{{ .Values.some_group }}"
               resources:
                 - "{{ .Values.some_resource }}"
+              resourceNames:
+                - "{{ .Values.some_name }}"
               verbs:
                 - "{{ .Values.some_verb }}"
           subjects:
@@ -64,6 +66,8 @@ tests:
                 - apps
               resources:
                 - deployments
+              resourceNames:
+                - some-name
               verbs:
                 - list
       - documentIndex: &roleBinding 3

--- a/library/common-test/tests/rbac/validation_test.yaml
+++ b/library/common-test/tests/rbac/validation_test.yaml
@@ -156,6 +156,25 @@ tests:
       - failedTemplate:
           errorMessage: RBAC - Expected non-empty entry in <rbac.rules.resources>
 
+  - it: should fail with empty entry in resourceNames in rules in rbac
+    set:
+      rbac:
+        my-rbac:
+          enabled: true
+          primary: true
+          rules:
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+              resourceNames:
+                - ""
+              verbs:
+                - get
+    asserts:
+      - failedTemplate:
+          errorMessage: RBAC - Expected non-empty entry in <rbac.rules.resourceNames>
+
   - it: should fail with empty entry in verbs in rules in rbac
     set:
       rbac:

--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A library chart for iX Official Catalog
 type: library
-version: 1.2.5
+version: 1.2.6
 appVersion: v1
 annotations:
   title: Common Library Chart

--- a/library/common/templates/lib/rbac/_rules.tpl
+++ b/library/common/templates/lib/rbac/_rules.tpl
@@ -36,7 +36,17 @@ objectData: The object data to be used to render the RBAC.
         {{- fail "RBAC - Expected non-empty entry in <rbac.rules.resources>" -}}
       {{- end }}
   - {{ tpl . $rootCtx | quote }}
-      {{- end -}}
+    {{- end -}}
+  {{- /* resourceNames */}}
+  {{- if .resourceNames }}
+  resourceNames:
+    {{- range .resourceNames -}}
+      {{- if not . -}}
+        {{- fail "RBAC - Expected non-empty entry in <rbac.rules.resourceNames>" -}}
+      {{- end }}
+  - {{ tpl . $rootCtx | quote }}
+    {{- end -}}
+  {{- end -}}
   {{- /* verbs */}}
   verbs:
     {{- range .verbs -}}


### PR DESCRIPTION
While investigating something else, I noticed the `resourceNames` field was missing from the common lib.
This is used to restrict the access to specific resource names when an RBAC/ServiceAccount is set.
This adds support for it, and can be consumed in apps if we need to.