### PR TITLE
fix(vaultwarden): pass ixChartContext to postgres template

### DIFF
--- a/library/ix-dev/community/vaultwarden/Chart.yaml
+++ b/library/ix-dev/community/vaultwarden/Chart.yaml
@@ -3,7 +3,7 @@ description: Alternative implementation of the Bitwarden server API written in R
 annotations:
   title: Vaultwarden
 type: application
-version: 1.1.5
+version: 1.1.6
 apiVersion: v2
 appVersion: 1.30.1
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/vaultwarden/templates/_postgres.tpl
+++ b/library/ix-dev/community/vaultwarden/templates/_postgres.tpl
@@ -1,7 +1,9 @@
 {{- define "postgres.workload" -}}
 {{/* Postgres Database */}}
 workload:
-{{- include "ix.v1.common.app.postgres" (dict "secretName" "postgres-creds" "resources" .Values.resources) | nindent 2 }}
+{{- include "ix.v1.common.app.postgres" (dict "secretName" "postgres-creds"
+                                              "resources" .Values.resources
+                                              "ixChartContext" .Values.ixChartContext) | nindent 2 }}
 
 {{/* Service */}}
 service:


### PR DESCRIPTION
Fixes #1987

Postgres template didn't have the ixChartContext details, so it didn't know the state of the app.
This resulted in attempts to backup the database, which wasn't running