### PR TITLE
update kapowarr and adapt to updstream changes

### DIFF
--- a/library/ix-dev/community/kapowarr/Chart.yaml
+++ b/library/ix-dev/community/kapowarr/Chart.yaml
@@ -3,7 +3,7 @@ description: Kapowarr is a software to build and manage a comic book library, fi
 annotations:
   title: Kapowarr
 type: application
-version: 1.2.1
+version: 2.0.0
 apiVersion: v2
 appVersion: 1.0.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/kapowarr/metadata.yaml
+++ b/library/ix-dev/community/kapowarr/metadata.yaml
@@ -1,8 +1,8 @@
 runAsContext:
-  - userName: kapowarr
-    groupName: kapowarr
-    gid: 568
-    uid: 568
-    description: Kapowarr can run as any non-root user.
+  - userName: root
+    groupName: root
+    gid: 0
+    uid: 0
+    description: Kapowarr runs as root user.
 capabilities: []
 hostMounts: []

--- a/library/ix-dev/community/kapowarr/questions.yaml
+++ b/library/ix-dev/community/kapowarr/questions.yaml
@@ -50,29 +50,6 @@ questions:
                         type: string
                         required: true
 
-  - variable: kapowarrRunAs
-    label: ""
-    group: User and Group Configuration
-    schema:
-      type: dict
-      attrs:
-        - variable: user
-          label: User ID
-          description: The user id that Kapowarr will run as.
-          schema:
-            type: int
-            min: 2
-            default: 568
-            required: true
-        - variable: group
-          label: Group ID
-          description: The group id that Kapowarr will run as.
-          schema:
-            type: int
-            min: 2
-            default: 568
-            required: true
-
   - variable: kapowarrNetwork
     label: ""
     group: Network Configuration

--- a/library/ix-dev/community/kapowarr/templates/_kapowarr.tpl
+++ b/library/ix-dev/community/kapowarr/templates/_kapowarr.tpl
@@ -12,8 +12,9 @@ workload:
           primary: true
           imageSelector: image
           securityContext:
-            runAsUser: {{ .Values.kapowarrRunAs.user }}
-            runAsGroup: {{ .Values.kapowarrRunAs.group }}
+            runAsUser: 0
+            runAsGroup: 0
+            runAsNonRoot: false
           {{ with .Values.kapowarrConfig.additionalEnvs }}
           envList:
             {{ range $env := . }}
@@ -37,10 +38,4 @@ workload:
               type: http
               port: 5656
               path: /
-      initContainers:
-      {{- include "ix.v1.common.app.permissions" (dict "containerName" "01-permissions"
-                                                        "UID" .Values.kapowarrRunAs.user
-                                                        "GID" .Values.kapowarrRunAs.group
-                                                        "mode" "check"
-                                                        "type" "install") | nindent 8 }}
 {{- end -}}

--- a/library/ix-dev/community/kapowarr/templates/_persistence.tpl
+++ b/library/ix-dev/community/kapowarr/templates/_persistence.tpl
@@ -2,63 +2,32 @@
 persistence:
   config:
     enabled: true
-    {{- include "kapowarr.storage.ci.migration" (dict "storage" .Values.kapowarrStorage.config) }}
     {{- include "ix.v1.common.app.storageOptions" (dict "storage" .Values.kapowarrStorage.config) | nindent 4 }}
     targetSelector:
       kapowarr:
         kapowarr:
           mountPath: /app/db
-        {{- if and (eq .Values.kapowarrStorage.config.type "ixVolume")
-                  (not (.Values.kapowarrStorage.config.ixVolumeConfig | default dict).aclEnable) }}
-        01-permissions:
-          mountPath: /mnt/directories/config
-        {{- end }}
   downloads:
     enabled: true
-    {{- include "kapowarr.storage.ci.migration" (dict "storage" .Values.kapowarrStorage.downloads) }}
     {{- include "ix.v1.common.app.storageOptions" (dict "storage" .Values.kapowarrStorage.downloads) | nindent 4 }}
     targetSelector:
       kapowarr:
         kapowarr:
           mountPath: /app/temp_downloads
-        {{- if and (eq .Values.kapowarrStorage.downloads.type "ixVolume")
-                  (not (.Values.kapowarrStorage.downloads.ixVolumeConfig | default dict).aclEnable) }}
-        01-permissions:
-          mountPath: /mnt/directories/downloads
-        {{- end }}
   content:
     enabled: true
-    {{- include "kapowarr.storage.ci.migration" (dict "storage" .Values.kapowarrStorage.content) }}
     {{- include "ix.v1.common.app.storageOptions" (dict "storage" .Values.kapowarrStorage.content) | nindent 4 }}
     targetSelector:
       kapowarr:
         kapowarr:
           mountPath: /content
-        {{- if and (eq .Values.kapowarrStorage.content.type "ixVolume")
-                  (not (.Values.kapowarrStorage.content.ixVolumeConfig | default dict).aclEnable) }}
-        01-permissions:
-          mountPath: /mnt/directories/content
-        {{- end }}
   {{- range $idx, $storage := .Values.kapowarrStorage.additionalStorages }}
   {{ printf "kapowarr-%v:" (int $idx) }}
     enabled: true
-    {{- include "kapowarr.storage.ci.migration" (dict "storage" $storage) }}
     {{- include "ix.v1.common.app.storageOptions" (dict "storage" $storage) | nindent 4 }}
     targetSelector:
       kapowarr:
         kapowarr:
           mountPath: {{ $storage.mountPath }}
-        01-permissions:
-          mountPath: /mnt/directories{{ $storage.mountPath }}
   {{- end }}
-{{- end -}}
-
-{{/* TODO: Remove on the next version bump, eg 1.2.0+ */}}
-{{- define "kapowarr.storage.ci.migration" -}}
-  {{- $storage := .storage -}}
-
-  {{- if $storage.hostPath -}}
-    {{- $_ := set $storage "hostPathConfig" dict -}}
-    {{- $_ := set $storage.hostPathConfig "hostPath" $storage.hostPath -}}
-  {{- end -}}
 {{- end -}}

--- a/library/ix-dev/community/kapowarr/values.yaml
+++ b/library/ix-dev/community/kapowarr/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: mrcas/kapowarr
   pullPolicy: IfNotPresent
-  tag: v1.0.0-beta-3
+  tag: v1.0.0-beta-4
 
 resources:
   limits:
@@ -13,10 +13,6 @@ kapowarrConfig:
 
 kapowarrNetwork:
   webPort: 30071
-
-kapowarrRunAs:
-  user: 568
-  group: 568
 
 kapowarrStorage:
   config:


### PR DESCRIPTION
Latest update does not run rootless anymore, this PR adapts to that change.

Marked it as "major" version upgrade, as it is kinda a breaking change in users workflow.
Other than that an upgrade should just work, just new files will be now owned by root.