### PR TITLE
fix(nextcloud): reference correct variable name

### DIFF
--- a/library/ix-dev/charts/nextcloud/Chart.yaml
+++ b/library/ix-dev/charts/nextcloud/Chart.yaml
@@ -4,7 +4,7 @@ description: A file sharing server that puts the control and security of your ow
 annotations:
   title: Nextcloud
 type: application
-version: 1.6.55
+version: 1.6.56
 apiVersion: v2
 appVersion: 28.0.1
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/nextcloud/templates/deployment.yaml
+++ b/library/ix-dev/charts/nextcloud/templates/deployment.yaml
@@ -83,7 +83,7 @@ spec: {{ include "common.deployment.common_spec" . | nindent 2 }}
         {{ if eq (include "nginx.certAvailable" .) "true" }}
         {{ $envList = mustAppend $envList (dict "name" "APACHE_DISABLE_REWRITE_IP" "value" "1") }}
           {{ if and .Values.nextcloud.host .Values.service.nodePort }}
-            {{ if .Values.nginxConfig.use443 }}
+            {{ if .Values.nginxConfig.useDifferentAccessPort }}
         {{ $envList = mustAppend $envList (dict "name" "OVERWRITEHOST" "value" .Values.nextcloud.host) }}
             {{ else }}
         {{ $envList = mustAppend $envList (dict "name" "OVERWRITEHOST" "value" (printf "%v:%v" .Values.nextcloud.host .Values.service.nodePort)) }}


### PR DESCRIPTION
In questions.yaml and values.yaml the variable name is different, but on the template it wasn't updated.