### PR TITLE
jellyfin - account for an extended versioning scheme

### DIFF
--- a/library/ix-dev/community/jellyfin/upgrade_strategy
+++ b/library/ix-dev/community/jellyfin/upgrade_strategy
@@ -6,12 +6,12 @@ import sys
 from catalog_update.upgrade_strategy import semantic_versioning
 
 
-RE_STABLE_VERSION = re.compile(r'[0-9]+\.[0-9]+\.[0-9]+')
+RE_STABLE_VERSION = re.compile(r'\d+\.\d+\.\d+(-\d+)?')
 
 
 def newer_mapping(image_tags):
     key = list(image_tags.keys())[0]
-    tags = {t: t for t in image_tags[key] if RE_STABLE_VERSION.fullmatch(t)}
+    tags = {t.replace("-", "."): t for t in image_tags[key] if RE_STABLE_VERSION.fullmatch(t)}
     version = semantic_versioning(list(tags))
     if not version:
         return {}


### PR DESCRIPTION
Fixes https://github.com/truenas/charts/issues/2050

Matches both 
major.minor.patch and major.minor.patch-revision

Local tests shows that works as expected

eg 1.2.3 is newer than 1.2.2-1
and 1.2.2-2 is newer than 1.2.2-1