### PR TITLE
allow overriding backupSecretName on postgres template

### DIFF
--- a/library/common/Chart.yaml
+++ b/library/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A library chart for iX Official Catalog
 type: library
-version: 1.2.8
+version: 1.2.9
 appVersion: v1
 annotations:
   title: Common Library Chart

--- a/library/common/templates/app_functions/_postgres.tpl
+++ b/library/common/templates/app_functions/_postgres.tpl
@@ -15,6 +15,7 @@ backupChownMode (optional): Whether to chown the backup directory or
   {{- $name := .name | default "postgres" -}}
   {{- $imageSelector := .imageSelector | default "postgresImage" -}}
   {{- $secretName := (required "Postgres - Secret Name is required" .secretName) -}}
+  {{- $backupSecretName := .backupSecretName | default $secretName -}}
   {{- $backupPath := .backupPath | default "/postgres_backup" -}}
   {{- $backupChownMode := .backupChownMode | default "check" -}}
   {{- $ixChartContext := .ixChartContext -}}
@@ -119,7 +120,7 @@ postgresbackup:
             memory: 2Gi
         envFrom:
           - secretRef:
-              name: {{ $secretName }}
+              name: {{ $backupSecretName }}
         command:
           - sh
           - -c


### PR DESCRIPTION
Problem:

During a migration from old common lib to new, the `new` secret is not yet created, so pre-upgrade backup job is failing.

Solution:
Allow to override the secret for the backup pre-upgrade job (a pre-upgrade secret will be created with a helm hook) and attached to the job.