### PR TITLE
Allow Volumes to be mounted in Tailscale to avoid machine name duplication on chart update

### DIFF
--- a/community/tailscale/1.0.31/ix_values.yaml
+++ b/community/tailscale/1.0.31/ix_values.yaml
@@ -21,3 +21,9 @@ tailscaleConfig:
 
 tailscaleNetwork:
   hostNetwork: false
+
+config:
+  type: ixVolume
+  ixVolumeConfig:
+  datasetName: config
+  additionalStorages: []


### PR DESCRIPTION
Add option to allow volumes to be mounted to allow the following volumes to be mounted:

      - '/dev/net/tun:/dev/net/tun'
      - '/var/lib:/var/lib'

Mounting these volumes allows tailscale to be updated WITHOUT causing the machine name to be duplicated. As it stands today, EVERY TIME the chart is updated, it causes the machine to be duplicated (and the name changed since the machine already exists). eg. If the machine name is 'server' and the chart is updated, when the chart re-deploys, it tries to register a new machine as 'server', fails to do so (since that machine already exists), and instead deploys as 'server-1'. This is a major annoyance.