### PR TITLE
fix collabora upgrade

### DIFF
--- a/library/ix-dev/charts/collabora/Chart.yaml
+++ b/library/ix-dev/charts/collabora/Chart.yaml
@@ -4,7 +4,7 @@ description: Collabora is a collaborative online office suite based on LibreOffi
 annotations:
   title: Collabora
 type: application
-version: 2.0.3
+version: 2.0.4
 apiVersion: v2
 appVersion: 23.05.8.4.1
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/collabora/ci/noauth-values.yaml
+++ b/library/ix-dev/charts/collabora/ci/noauth-values.yaml
@@ -1,0 +1,17 @@
+collaboraConfig:
+  enableWebUI: false
+  username: ''
+  password: ''
+  dictionaries:
+    - en_GB
+    - en_US
+  aliasGroup1:
+    - nc.example.com
+    - other-nc.example.com
+  serverName: collabora.example.com:9980
+  extraParams:
+    - --o:welcome.enable=false
+    - --o:user_interface.mode=notebookbar
+    - --o:ssl.termination=true
+    - --o:ssl.enable=false
+    - --o:net.proto=IPv4

--- a/library/ix-dev/charts/collabora/questions.yaml
+++ b/library/ix-dev/charts/collabora/questions.yaml
@@ -58,7 +58,7 @@ questions:
             default: ""
             private: true
             show_if: [[enableWebUI, "=", true]]
-            valid_chars: "[a-zA-Z0-9!@#%^&*?]{8,}"
+            valid_chars: "^[a-zA-Z0-9!@#%^&*?]{8,}$|^$"
             valid_chars_error: |
               Password must be at least 8 characters long and contain at least one of the following:</br>
               - Uppercase letter</br>

--- a/library/ix-dev/charts/collabora/questions.yaml
+++ b/library/ix-dev/charts/collabora/questions.yaml
@@ -49,6 +49,7 @@ questions:
           label: Username for WebUI
           schema:
             type: string
+            required: true
             show_if: [[enableWebUI, "=", true]]
             default: ""
         - variable: password
@@ -57,6 +58,7 @@ questions:
             type: string
             default: ""
             private: true
+            required: true
             show_if: [[enableWebUI, "=", true]]
             valid_chars: "^[a-zA-Z0-9!@#%^&*?]{8,}$|^$"
             valid_chars_error: |

--- a/library/ix-dev/charts/collabora/questions.yaml
+++ b/library/ix-dev/charts/collabora/questions.yaml
@@ -51,14 +51,12 @@ questions:
             type: string
             show_if: [[enableWebUI, "=", true]]
             default: ""
-            required: true
         - variable: password
           label: Password for WebUI
           schema:
             type: string
             default: ""
             private: true
-            required: true
             show_if: [[enableWebUI, "=", true]]
             valid_chars: "[a-zA-Z0-9!@#%^&*?]{8,}"
             valid_chars_error: |

--- a/library/ix-dev/charts/collabora/templates/_collabora.tpl
+++ b/library/ix-dev/charts/collabora/templates/_collabora.tpl
@@ -31,8 +31,8 @@ workload:
             extra_params: {{ join " " .Values.collaboraConfig.extraParams }}
             DONT_GEN_SSL_CERT: "true"
             {{- if .Values.collaboraConfig.enableWebUI }}
-            username: {{ .Values.collaboraConfig.username | required "Collabora - Username is required when Enable WebUI is checked" }}
-            password: {{ .Values.collaboraConfig.password | required "Collabora - Password is required when Enable WebUI is checked" }}
+            username: {{ .Values.collaboraConfig.username }}
+            password: {{ .Values.collaboraConfig.password }}
             {{- end }}
             {{- if not (contains ":" .Values.collaboraConfig.serverName) }}
             server_name: {{ printf "%s:%v" .Values.collaboraConfig.serverName .Values.collaboraNetwork.webPort }}

--- a/library/ix-dev/charts/collabora/templates/_collabora.tpl
+++ b/library/ix-dev/charts/collabora/templates/_collabora.tpl
@@ -31,8 +31,8 @@ workload:
             extra_params: {{ join " " .Values.collaboraConfig.extraParams }}
             DONT_GEN_SSL_CERT: "true"
             {{- if .Values.collaboraConfig.enableWebUI }}
-            username: {{ .Values.collaboraConfig.username }}
-            password: {{ .Values.collaboraConfig.password }}
+            username: {{ .Values.collaboraConfig.username | required "Collabora - Username is required when Enable WebUI is checked" }}
+            password: {{ .Values.collaboraConfig.password | required "Collabora - Password is required when Enable WebUI is checked" }}
             {{- end }}
             {{- if not (contains ":" .Values.collaboraConfig.serverName) }}
             server_name: {{ printf "%s:%v" .Values.collaboraConfig.serverName .Values.collaboraNetwork.webPort }}


### PR DESCRIPTION
Allow empty string in regex for password. as it blocks the upgrade.
(See #2132)