### PR TITLE
fix upgrade strategy on 2 apps

### DIFF
--- a/library/ix-dev/charts/pihole/upgrade_strategy
+++ b/library/ix-dev/charts/pihole/upgrade_strategy
@@ -16,6 +16,16 @@ def newer_mapping(image_tags):
     if not version:
         return {}
 
+    parts = version.split('.')
+    for idx, val in enumerate(parts):
+        if val == '0':
+            continue
+
+        if len(val) == 1:
+            parts[idx] = '0' + val
+
+    version = '.'.join(parts)
+
     return {
         'tags': {key: tags[version]},
         'app_version': version,

--- a/library/ix-dev/community/handbrake/upgrade_strategy
+++ b/library/ix-dev/community/handbrake/upgrade_strategy
@@ -11,20 +11,21 @@ RE_STABLE_VERSION = re.compile(r'v\d+\.\d+\.\d+')
 
 def newer_mapping(image_tags):
     key = list(image_tags.keys())[0]
-    temp_tags = {t.strip('v'): t for t in image_tags[key] if RE_STABLE_VERSION.fullmatch(t)}
-
-    # Strip leading zeros
-    tags = {}
-    for tag in temp_tags:
-        tag = tag.split('.')
-        for i in range(len(tag)):
-            # Remove leading zeros
-            tag[i] = tag[i].lstrip('0')
-        tags[tag] = '.'.join(tag)
-
+    tags = {t.strip('v'): t for t in image_tags[key] if RE_STABLE_VERSION.fullmatch(t)}
     version = semantic_versioning(list(tags))
+
     if not version:
         return {}
+
+    parts = version.split('.')
+    for idx, val in enumerate(parts):
+        if val == '0':
+            continue
+
+        if len(val) == 1:
+            parts[idx] = '0' + val
+
+    version = '.'.join(parts)
 
     return {
         'tags': {key: tags[version]},


### PR DESCRIPTION
semantic_versioning function removes leading zeros,
Re-add them after we find the right version so the tags[version] won't fail with key error and also get the correct version tag