### PR TITLE
syncthing - allow 0 for puid/pgid

### DIFF
--- a/library/ix-dev/charts/syncthing/Chart.yaml
+++ b/library/ix-dev/charts/syncthing/Chart.yaml
@@ -3,7 +3,7 @@ description: Syncthing is a continuous file synchronization program.
 annotations:
   title: Syncthing
 type: application
-version: 2.0.0
+version: 2.0.1
 apiVersion: v2
 appVersion: 1.27.3
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/syncthing/questions.yaml
+++ b/library/ix-dev/charts/syncthing/questions.yaml
@@ -63,7 +63,7 @@ questions:
           description: The user id that Syncthing files will be owned by.
           schema:
             type: int
-            min: 568
+            min: 0
             default: 568
             required: true
         - variable: group
@@ -71,7 +71,7 @@ questions:
           description: The group id that Syncthing files will be owned by.
           schema:
             type: int
-            min: 568
+            min: 0
             default: 568
             required: true
 

--- a/library/ix-dev/charts/syncthing/templates/_syncthing.tpl
+++ b/library/ix-dev/charts/syncthing/templates/_syncthing.tpl
@@ -5,7 +5,7 @@ workload:
     primary: true
     type: Deployment
     podSpec:
-      securityContenxt:
+      securityContext:
         fsGroup: {{ .Values.syncthingID.group }}
       hostNetwork: {{ .Values.syncthingNetwork.hostNetwork }}
       containers:


### PR DESCRIPTION
Fixes #2199 

The POD already runs as root, this allows the binary inside that pod to also run as root.


Note that PUID/PGID are only "indications" to syncthing that the binary should run under this ids. but that's up to syncthing to respect or not.