### PR TITLE
Fix Odoo chart version

### DIFF
--- a/library/ix-dev/community/odoo/Chart.yaml
+++ b/library/ix-dev/community/odoo/Chart.yaml
@@ -3,7 +3,7 @@ description: Odoo is a suite of web based open source business apps.
 annotations:
   title: Odoo
 type: application
-version: 2.0.7
+version: 2.0.8
 apiVersion: v2
 appVersion: '17.0'
 kubeVersion: '>=1.16.0-0'


### PR DESCRIPTION
As it can be see in [this ix_values](https://github.com/truenas/charts/blob/master/community/odoo/2.0.7/ix_values.yaml#L4), the app version for the chart v2.0.7 is actually `17.0` and not `16.0`