### PR TITLE
n8n - change execution mode

### DIFF
--- a/library/ix-dev/community/n8n/Chart.yaml
+++ b/library/ix-dev/community/n8n/Chart.yaml
@@ -3,7 +3,7 @@ description: n8n is an extendable workflow automation tool.
 annotations:
   title: n8n
 type: application
-version: 1.2.24
+version: 1.2.25
 apiVersion: v2
 appVersion: 1.30.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/n8n/templates/_configuration.tpl
+++ b/library/ix-dev/community/n8n/templates/_configuration.tpl
@@ -51,7 +51,7 @@ secret:
     data:
       N8N_ENCRYPTION_KEY: {{ $encKey }}
       DB_TYPE: postgresdb
-      EXECUTIONS_MODE: regural
+      EXECUTIONS_MODE: regular
       DB_POSTGRESDB_USER: {{ $dbUser }}
       DB_POSTGRESDB_PASSWORD: {{ $dbPass }}
       DB_POSTGRESDB_DATABASE: {{ $dbName }}

--- a/library/ix-dev/community/n8n/templates/_configuration.tpl
+++ b/library/ix-dev/community/n8n/templates/_configuration.tpl
@@ -51,7 +51,7 @@ secret:
     data:
       N8N_ENCRYPTION_KEY: {{ $encKey }}
       DB_TYPE: postgresdb
-      EXECUTIONS_MODE: queue
+      EXECUTIONS_MODE: regural
       DB_POSTGRESDB_USER: {{ $dbUser }}
       DB_POSTGRESDB_PASSWORD: {{ $dbPass }}
       DB_POSTGRESDB_DATABASE: {{ $dbName }}
@@ -82,7 +82,4 @@ configmap:
       N8N_SSL_KEY: /certs/tls.key
       N8N_SSL_CERT: /certs/tls.crt
       {{- end }}
-      # https://github.com/n8n-io/n8n/issues/8664#issuecomment-1952155450
-      SHELL: /bin/sh
-
 {{- end -}}


### PR DESCRIPTION
Fixes #2210 

- Changes `EXECUTION_MODE` to `regular`, as the current `queue` value is only useful if you have additional workers to pick up the work. 
- Removes a temporary fix that is no longer needed on the newer container tag.