### PR TITLE
extend startup probes on few apps

### DIFF
--- a/library/ix-dev/community/castopod/Chart.yaml
+++ b/library/ix-dev/community/castopod/Chart.yaml
@@ -4,7 +4,7 @@ description: Castopod is an open-source hosting platform made for podcasters who
 annotations:
   title: Castopod
 type: application
-version: 1.2.13
+version: 1.2.14
 apiVersion: v2
 appVersion: 1.10.3
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/castopod/templates/_castopod.tpl
+++ b/library/ix-dev/community/castopod/templates/_castopod.tpl
@@ -48,6 +48,9 @@ workload:
               enabled: true
               type: tcp
               port: 9000
+              spec:
+                initialDelaySeconds: 30
+                failureThreshold: 150
       initContainers:
       {{- include "ix.v1.common.app.redisWait" (dict  "name" "01-redis-wait"
                                                       "secretName" "redis-creds") | nindent 8 }}

--- a/library/ix-dev/community/castopod/templates/_castopod.tpl
+++ b/library/ix-dev/community/castopod/templates/_castopod.tpl
@@ -50,7 +50,7 @@ workload:
               port: 9000
               spec:
                 initialDelaySeconds: 30
-                failureThreshold: 150
+                failureThreshold: 180
       initContainers:
       {{- include "ix.v1.common.app.redisWait" (dict  "name" "01-redis-wait"
                                                       "secretName" "redis-creds") | nindent 8 }}

--- a/library/ix-dev/community/nginx-proxy-manager/Chart.yaml
+++ b/library/ix-dev/community/nginx-proxy-manager/Chart.yaml
@@ -3,7 +3,7 @@ description: Expose your services easily and securely
 annotations:
   title: Nginx Proxy Manager
 type: application
-version: 1.0.27
+version: 1.0.28
 apiVersion: v2
 appVersion: 2.11.1
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/nginx-proxy-manager/templates/_npm.tpl
+++ b/library/ix-dev/community/nginx-proxy-manager/templates/_npm.tpl
@@ -58,7 +58,7 @@ workload:
               command: /bin/check-health
               spec:
                 initialDelaySeconds: 30
-                failureThreshold: 120
+                failureThreshold: 150
 {{/* Service */}}
 service:
   npm:

--- a/library/ix-dev/community/nginx-proxy-manager/templates/_npm.tpl
+++ b/library/ix-dev/community/nginx-proxy-manager/templates/_npm.tpl
@@ -58,7 +58,7 @@ workload:
               command: /bin/check-health
               spec:
                 initialDelaySeconds: 30
-                failureThreshold: 150
+                failureThreshold: 180
 {{/* Service */}}
 service:
   npm:

--- a/library/ix-dev/community/paperless-ngx/Chart.yaml
+++ b/library/ix-dev/community/paperless-ngx/Chart.yaml
@@ -4,7 +4,7 @@ description: Paperless-ngx is a document management system that transforms your 
 annotations:
   title: Paperless-ngx
 type: application
-version: 1.2.26
+version: 1.2.27
 apiVersion: v2
 appVersion: 2.5.3
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/paperless-ngx/templates/_paperless.tpl
+++ b/library/ix-dev/community/paperless-ngx/templates/_paperless.tpl
@@ -53,7 +53,7 @@ workload:
               path: /
               spec:
                 initialDelaySeconds: 30
-                failureThreshold: 150
+                failureThreshold: 180
       initContainers:
       {{- include "ix.v1.common.app.permissions" (dict "containerName" "01-permissions"
                                                         "UID" .Values.paperlessID.user

--- a/library/ix-dev/community/paperless-ngx/templates/_paperless.tpl
+++ b/library/ix-dev/community/paperless-ngx/templates/_paperless.tpl
@@ -51,6 +51,9 @@ workload:
               type: http
               port: {{ .Values.paperlessNetwork.webPort }}
               path: /
+              spec:
+                initialDelaySeconds: 30
+                failureThreshold: 150
       initContainers:
       {{- include "ix.v1.common.app.permissions" (dict "containerName" "01-permissions"
                                                         "UID" .Values.paperlessID.user


### PR DESCRIPTION
Extends startup probes on apps that seem to do some expensive IO ops (like chown or chmod) at startup.
While this is not one-size-fits-all solution, it should help cover most cases.

The default startup probe time was 60 failures with 5 sec interval (5minutes)
Now its 180 failures with 5 sec interval (15 minutes).

Closes #2179
Closes #1212