### PR TITLE
fix ix-chart resources

### DIFF
--- a/library/ix-dev/charts/ix-chart/Chart.yaml
+++ b/library/ix-dev/charts/ix-chart/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart for deploying simple workloads Kubernetes
 annotations:
   title: ix-chart
 type: application
-version: 2308.0.1
+version: 2403.0.0
 apiVersion: v2
 appVersion: v1
 kubeVersion: ">=1.16.0-0"

--- a/library/ix-dev/charts/ix-chart/templates/_containers.tpl
+++ b/library/ix-dev/charts/ix-chart/templates/_containers.tpl
@@ -64,14 +64,3 @@ ports:
   {{- end }}
 {{- end }}
 {{- end }}
-
-{{/*
-Container Resource Configuration
-*/}}
-{{- define "containerResourceConfiguration" }}
-{{- if .Values.gpuConfiguration }}
-resources:
-  limits:
-    {{- toYaml .Values.gpuConfiguration | nindent 4 }}
-{{- end }}
-{{- end }}

--- a/library/ix-dev/charts/ix-chart/templates/_workload.tpl
+++ b/library/ix-dev/charts/ix-chart/templates/_workload.tpl
@@ -111,7 +111,6 @@ containers:
   {{- include "containerEnvVariables" . | indent 2 }}
   {{- include "containerLivenssProbe" . | indent 2 }}
   {{- include "containerPorts" . | indent 2 }}
-  {{- include "containerResourceConfiguration" . | indent 2 }}
 {{- include "volumeConfiguration" . }}
 {{- include "dnsConfiguration" . }}
 {{- end }}


### PR DESCRIPTION
We have a duplicate template rendered the same key with different contents underneath.
In this case the second key was having less values that then first one, and since yaml only keeps the last occurrence, 
all the information was lost.

Removed the second resource rendering, and kept the one that comes from the common lib.
Which also handles GPU, so its feature parity.