### PR TITLE
invidious: switch to tcp probe

### DIFF
--- a/library/ix-dev/community/invidious/Chart.yaml
+++ b/library/ix-dev/community/invidious/Chart.yaml
@@ -3,10 +3,10 @@ description: Invidious is an alternative front-end to YouTube
 annotations:
   title: Invidious
 type: application
-version: 2.0.0
+version: 2.0.1
 apiVersion: v2
 appVersion: latest
-kubeVersion: '>=1.16.0-0'
+kubeVersion: ">=1.16.0-0"
 maintainers:
   - name: truenas
     url: https://www.truenas.com/

--- a/library/ix-dev/community/invidious/Chart.yaml
+++ b/library/ix-dev/community/invidious/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 version: 2.0.1
 apiVersion: v2
 appVersion: latest
-kubeVersion: ">=1.16.0-0"
+kubeVersion: '>=1.16.0-0'
 maintainers:
   - name: truenas
     url: https://www.truenas.com/

--- a/library/ix-dev/community/invidious/templates/_invidious.tpl
+++ b/library/ix-dev/community/invidious/templates/_invidious.tpl
@@ -26,18 +26,15 @@ workload:
           probes:
             liveness:
               enabled: true
-              type: http
-              path: /api/v1/comments/jNQXAC9IVRw
+              type: tcp
               port: {{ .Values.invidiousNetwork.webPort }}
             readiness:
               enabled: true
-              type: http
-              path: /api/v1/comments/jNQXAC9IVRw
+              type: tcp
               port: {{ .Values.invidiousNetwork.webPort }}
             startup:
               enabled: true
-              type: http
-              path: /api/v1/comments/jNQXAC9IVRw
+              type: tcp
               port: {{ .Values.invidiousNetwork.webPort }}
       initContainers:
         {{- include "ix.v1.common.app.permissions" (dict "containerName" "01-permissions"


### PR DESCRIPTION
Fixes #2364
Looks like invidious endpoints are linked with YT api too.
https://github.com/iv-org/invidious/issues/4497

Move away from that endpoint for healthcheck. Use TCP probes.