### PR TITLE
minio/charts: fix migration

### DIFF
--- a/library/ix-dev/charts/minio/Chart.yaml
+++ b/library/ix-dev/charts/minio/Chart.yaml
@@ -3,7 +3,7 @@ description: High Performance, Kubernetes Native Object Storage
 annotations:
   title: MinIO
 type: application
-version: 2.0.4
+version: 2.0.5
 apiVersion: v2
 appVersion: "2023-03-13"
 kubeVersion: ">=1.16.0-0"

--- a/library/ix-dev/charts/minio/migrations/migrate
+++ b/library/ix-dev/charts/minio/migrations/migrate
@@ -26,8 +26,11 @@ def migrate_common_lib(values):
         'appVolumeMounts', 'extraAppVolumeMounts', 'postgresAppVolumeMounts', 'runAsUser', 'runAsGroup',
     ]
 
-    exportVol = migrate_volume(values['appVolumeMounts']['export'])
-    exportVol['mountPath'] = values['appVolumeMounts']['export']['mountPath']
+    exportVol = {}
+    if not values['distributedMode']:
+        exportVol = migrate_volume(values['appVolumeMounts']['export'])
+        exportVol['mountPath'] = values['appVolumeMounts']['export']['mountPath']
+
     values.update({
         # Migrate Config
         'minioConfig': {
@@ -87,13 +90,15 @@ def migrate_common_lib(values):
 
 def migrate(values):
     # If this missing, we have already migrated
-    if not 'appVolumeMounts' in values.keys():
+    if not 'accessKey' in values.keys():
         return values
 
     return migrate_common_lib(values)
 
 
 if __name__ == '__main__':
+    with open('in.json', 'r') as f:
+        print(json.dumps(migrate(json.loads(f.read()))))
     if len(sys.argv) != 2:
         exit(1)
 

--- a/library/ix-dev/charts/minio/migrations/migrate
+++ b/library/ix-dev/charts/minio/migrations/migrate
@@ -97,8 +97,6 @@ def migrate(values):
 
 
 if __name__ == '__main__':
-    with open('in.json', 'r') as f:
-        print(json.dumps(migrate(json.loads(f.read()))))
     if len(sys.argv) != 2:
         exit(1)
 


### PR DESCRIPTION
Fixes  #2341

Key `appVolumeMounts` does not exist when distributed mode is enabled.
In this case skip setting minio's `export` config