### PR TITLE
wg-easy: fix vpn port

### DIFF
--- a/library/ix-dev/charts/wg-easy/Chart.yaml
+++ b/library/ix-dev/charts/wg-easy/Chart.yaml
@@ -3,7 +3,7 @@ description: WG-Easy is the easiest way to install & manage WireGuard!
 annotations:
   title: WG Easy
 type: application
-version: 2.0.14
+version: 2.0.15
 apiVersion: v2
 appVersion: '12'
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/wg-easy/templates/_service.tpl
+++ b/library/ix-dev/charts/wg-easy/templates/_service.tpl
@@ -16,6 +16,7 @@ service:
         enabled: true
         port: {{ .Values.wgNetwork.udpPort }}
         nodePort: {{ .Values.wgNetwork.udpPort }}
+        targetPort: 51820
         protocol: udp
         targetSelector: wgeasy
 {{- end -}}


### PR DESCRIPTION
Fixes #2374

wg-easy hardcodes the _internal_ vpn port. 

We were defaulting the internal port to the user specified value.

Now we hardcode the internal port as well but still allow the user to change the external port to the desired value.