### PR TITLE
plex: give it more time on startup

### DIFF
--- a/library/ix-dev/charts/plex/Chart.yaml
+++ b/library/ix-dev/charts/plex/Chart.yaml
@@ -4,7 +4,7 @@ description: Plex is a media server that allows you to stream your media to any 
 annotations:
   title: Plex
 type: application
-version: 2.0.5
+version: 2.0.6
 apiVersion: v2
 appVersion: 1.40.2.8395
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/plex/templates/_plex.tpl
+++ b/library/ix-dev/charts/plex/templates/_plex.tpl
@@ -52,6 +52,9 @@ workload:
               enabled: true
               type: tcp
               port: 32400
+              spec:
+                initialDelaySeconds: 30
+                failureThreshold: 180
 
 {{ with .Values.plexGPU }}
 scaleGPU:


### PR DESCRIPTION
Some users experience a longer startup process depending on their database.

This Increases the startup timeout to triple the current time.