### PR TITLE
navidrome: disable rofs

### DIFF
--- a/library/ix-dev/community/navidrome/Chart.yaml
+++ b/library/ix-dev/community/navidrome/Chart.yaml
@@ -3,7 +3,7 @@ description: Navidrome is a personal streaming service
 annotations:
   title: Navidrome
 type: application
-version: 1.2.7
+version: 1.2.8
 apiVersion: v2
 appVersion: 0.52.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/navidrome/templates/_navidrome.tpl
+++ b/library/ix-dev/community/navidrome/templates/_navidrome.tpl
@@ -14,6 +14,7 @@ workload:
           securityContext:
             runAsUser: {{ .Values.navidromeRunAs.user }}
             runAsGroup: {{ .Values.navidromeRunAs.group }}
+            readOnlyRootFilesystem: false
           env:
             ND_MUSICFOLDER: /music
             ND_DATAFOLDER: /data


### PR DESCRIPTION
Seems that navidrome (or its underling db driver/library) uses some root path (does not seem to be `/tmp`) to store temporary files during migrations.
Not sure if it depends on the size of the database or not, but on a demo instance I had I couldnt reproduce, but I could on another's user system. But when it was using this root path, it was failing to write so the migration was failing as well.

For now I'll disable the readOnly root fs of the container, so migrations can execute without errors.

Fixes #2190 

Thanks to @virtualdxs for providing a system to troubleshoot/debug