### PR TITLE
nextcloud: fix migration

### DIFF
--- a/library/ix-dev/charts/nextcloud/Chart.yaml
+++ b/library/ix-dev/charts/nextcloud/Chart.yaml
@@ -4,7 +4,7 @@ description: A file sharing server that puts the control and security of your ow
 annotations:
   title: Nextcloud
 type: application
-version: 2.0.1
+version: 2.0.2
 apiVersion: v2
 appVersion: 29.0.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/nextcloud/migrations/migrate
+++ b/library/ix-dev/charts/nextcloud/migrations/migrate
@@ -93,13 +93,18 @@ def migrate_common_lib(values):
     return values
 
 def migrate(values):
-    if 'isDataInTheSameVolume' in values.keys():
+    if 'isDataInTheSameVolume' in values.keys() or 'shouldShowStorageToggle' in values.keys():
         values['ncStorage']['isDataInTheSameVolume'] = values.pop('isDataInTheSameVolume', True)
         values['ncStorage']['shouldShowStorageToggle'] = values.pop('shouldShowStorageToggle', True)
         return values
 
     # If this missing, we have already migrated
     if not 'appVolumeMounts' in values.keys():
+        # If 'shouldFixMigration' missing, we should fix migration and then add the key
+        if not 'migrationFixed' in values['ncStorage'].keys():
+            values['ncStorage']['shouldShowStorageToggle'] = True
+            values['ncStorage']['isDataInTheSameVolume'] = True
+            values['ncStorage']['migrationFixed'] = True
         return values
 
 

--- a/library/ix-dev/charts/nextcloud/questions.yaml
+++ b/library/ix-dev/charts/nextcloud/questions.yaml
@@ -259,7 +259,7 @@ questions:
           label: ""
           schema:
             type: boolean
-            default: false
+            default: true
             hidden: true
         - variable: isDataInTheSameVolume
           label: "Pre v2 Storage Structure (See the tooltip for more information)"

--- a/library/ix-dev/charts/nextcloud/questions.yaml
+++ b/library/ix-dev/charts/nextcloud/questions.yaml
@@ -254,6 +254,13 @@ questions:
             type: boolean
             default: false
             hidden: true
+        # Dummy variable so we can skip "fixing" migration on new installations
+        - variable: migrationFixed
+          label: ""
+          schema:
+            type: boolean
+            default: false
+            hidden: true
         - variable: isDataInTheSameVolume
           label: "Pre v2 Storage Structure (See the tooltip for more information)"
           description: |


### PR DESCRIPTION
Due to a bad initial migration, combined with a `show_if` in questions. resulted in a key missing that would retain backward compatibility with existing installs.

Needed to add a "dummy" key that would not exist for those that upgrade from 2.0.0/1 to 2.0.2.
So this should re-add this key, only to existing installations, fixing the issue.

New installs will have the key and no actions should happen.