### PR TITLE
nextcloud: fixes

### DIFF
--- a/charts/nextcloud/2.0.3/templates/_configuration.tpl
+++ b/charts/nextcloud/2.0.3/templates/_configuration.tpl
@@ -76,7 +76,7 @@ secret:
       APACHE_DISABLE_REWRITE_IP: "1"
       OVERWRITEPROTOCOL: "https"
       TRUSTED_PROXIES: {{ list  $svcCidr $clusterCidr "127.0.0.1" | mustUniq | join "," | quote }}
-      {{- if and .Values.ncConfig.host .Values.ncNetwork.webPort }}
+      {{- if and .Values.ncConfig.host }}
         {{- $overwritehost := .Values.ncConfig.host -}}
         {{- if .Values.ncNetwork.nginx.useDifferentAccessPort }}
           {{ $overwritehost = (printf "%v:%v" .Values.ncConfig.host .Values.ncNetwork.webPort) }}

--- a/charts/nextcloud/2.0.3/templates/_configuration.tpl
+++ b/charts/nextcloud/2.0.3/templates/_configuration.tpl
@@ -76,7 +76,7 @@ secret:
       APACHE_DISABLE_REWRITE_IP: "1"
       OVERWRITEPROTOCOL: "https"
       TRUSTED_PROXIES: {{ list  $svcCidr $clusterCidr "127.0.0.1" | mustUniq | join "," | quote }}
-      {{- if and .Values.ncConfig.host }}
+      {{- if and .Values.ncConfig.host .Values.ncNetwork.webPort }}
         {{- $overwritehost := .Values.ncConfig.host -}}
         {{- if .Values.ncNetwork.nginx.useDifferentAccessPort }}
           {{ $overwritehost = (printf "%v:%v" .Values.ncConfig.host .Values.ncNetwork.webPort) }}

--- a/library/ix-dev/charts/nextcloud/Chart.yaml
+++ b/library/ix-dev/charts/nextcloud/Chart.yaml
@@ -4,7 +4,7 @@ description: A file sharing server that puts the control and security of your ow
 annotations:
   title: Nextcloud
 type: application
-version: 2.0.3
+version: 2.0.4
 apiVersion: v2
 appVersion: 29.0.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/nextcloud/ci/nocmd-values.yaml
+++ b/library/ix-dev/charts/nextcloud/ci/nocmd-values.yaml
@@ -9,10 +9,7 @@ ncConfig:
 
 ncNetwork:
   webPort: 30001
-  nginx:
-    proxyTimeouts: 120
-    useDifferentAccessPort: false
-    externalAccessPort: 443
+  nginx: {}
 
 ncStorage:
   pgData:

--- a/library/ix-dev/charts/nextcloud/migrations/migrate
+++ b/library/ix-dev/charts/nextcloud/migrations/migrate
@@ -33,7 +33,7 @@ def migrate_common_lib(values):
                 'proxyTimeouts': values.get('nginxConfig', {}).get('proxy_timeouts', 60),
                 'useDifferentAccessPort': values.get('nginxConfig', {}).get('useDifferentAccessPort', False),
                 'externalAccessPort': values.get('nginxConfig', {}).get('externalAccessPort', 443)
-            }
+            } if values['certificate'] else {}
         },
         # Migrate Resources
         'resources': {
@@ -98,6 +98,9 @@ def migrate(values):
 
     # If this missing, we have already migrated
     if not 'appVolumeMounts' in values.keys():
+        if 'certificateID' in values['ncNetwork']:
+            if not values['ncNetwork']['certificateID']:
+                values['ncNetwork']['nginx'] = {}
         # If 'shouldFixMigration' missing, we should fix migration and then add the key
         if not 'migrationFixed' in values['ncStorage'].keys():
             values['ncStorage']['isDataInTheSameVolume'] = True

--- a/library/ix-dev/charts/nextcloud/migrations/migrate
+++ b/library/ix-dev/charts/nextcloud/migrations/migrate
@@ -70,7 +70,6 @@ def migrate_common_lib(values):
         },
         # Migrate Storage
         'ncStorage': {
-            'shouldShowStorageToggle': True,
             'isDataInTheSameVolume': True,
             'pgData': migrate_volume(values['postgresAppVolumeMounts']['postgres-data']),
             'pgBackup': migrate_volume(values['postgresAppVolumeMounts']['postgres-backup']),
@@ -93,16 +92,14 @@ def migrate_common_lib(values):
     return values
 
 def migrate(values):
-    if 'isDataInTheSameVolume' in values.keys() or 'shouldShowStorageToggle' in values.keys():
+    if 'isDataInTheSameVolume' in values.keys():
         values['ncStorage']['isDataInTheSameVolume'] = values.pop('isDataInTheSameVolume', True)
-        values['ncStorage']['shouldShowStorageToggle'] = values.pop('shouldShowStorageToggle', True)
         return values
 
     # If this missing, we have already migrated
     if not 'appVolumeMounts' in values.keys():
         # If 'shouldFixMigration' missing, we should fix migration and then add the key
         if not 'migrationFixed' in values['ncStorage'].keys():
-            values['ncStorage']['shouldShowStorageToggle'] = True
             values['ncStorage']['isDataInTheSameVolume'] = True
             values['ncStorage']['migrationFixed'] = True
         return values

--- a/library/ix-dev/charts/nextcloud/questions.yaml
+++ b/library/ix-dev/charts/nextcloud/questions.yaml
@@ -275,7 +275,7 @@ questions:
             show_if: [["shouldShowStorageToggle", "=", true]]
             default: false
         - variable: html
-          label: Nextcloud HTML Storage
+          label: Nextcloud AppData Storage (HTML, Custom Themes, Apps, etc.)
           description: The path to store Nextcloud HTML and AppData.
           schema:
             type: dict

--- a/library/ix-dev/charts/nextcloud/questions.yaml
+++ b/library/ix-dev/charts/nextcloud/questions.yaml
@@ -44,7 +44,12 @@ questions:
             required: true
         - variable: host
           label: Host
-          description: Nextcloud host to create application URLs
+          description: |
+            Nextcloud host to create application URLs</br>
+            Example: </br>
+            cloud.domain.com:30001</br>
+            or </br>
+            cloud.domain.com (if you use port 443 externally)</br>
           schema:
             type: string
             $ref:
@@ -774,7 +779,7 @@ questions:
                 schema:
                   type: string
                   max_length: 12
-                  valid_chars: '^[1-9][0-9]*([EPTGMK]i?|e[0-9]+)?$'
+                  valid_chars: "^[1-9][0-9]*([EPTGMK]i?|e[0-9]+)?$"
                   valid_chars_error: |
                     Valid Memory limit formats are</br>
                     - Suffixed with E/P/T/G/M/K - eg. 1G</br>

--- a/library/ix-dev/charts/nextcloud/questions.yaml
+++ b/library/ix-dev/charts/nextcloud/questions.yaml
@@ -253,12 +253,6 @@ questions:
     schema:
       type: dict
       attrs:
-        - variable: shouldShowStorageToggle
-          label: ""
-          schema:
-            type: boolean
-            default: false
-            hidden: true
         # Dummy variable so we can skip "fixing" migration on new installations
         - variable: migrationFixed
           label: ""
@@ -269,6 +263,7 @@ questions:
         - variable: isDataInTheSameVolume
           label: "Pre v2 Storage Structure (See the tooltip for more information)"
           description: |
+            Do NOT check this, if this is a new installation.</br>
             If this is checked, means that this is an installation coming from a previous version (v1.x.x).<br/>
             In order to have backwards compatibility, the older storage structure was kept for this installation.<br/>
             If you want to utilize the new storage structure, move 'data' in a separate directory or dataset.
@@ -277,7 +272,6 @@ questions:
             You will NOT likely want to change that if your setup uses ixVolume as storage.
           schema:
             type: boolean
-            show_if: [["shouldShowStorageToggle", "=", true]]
             default: false
         - variable: html
           label: Nextcloud AppData Storage (HTML, Custom Themes, Apps, etc.)

--- a/library/ix-dev/charts/nextcloud/questions.yaml
+++ b/library/ix-dev/charts/nextcloud/questions.yaml
@@ -46,10 +46,10 @@ questions:
           label: Host
           description: |
             Nextcloud host to create application URLs</br>
-            Example: </br>
+            Examples: </br>
             cloud.domain.com:30001</br>
-            or </br>
             cloud.domain.com (if you use port 443 externally)</br>
+            192.168.1.100:9001 (replace ip and port with your own)</br>
           schema:
             type: string
             $ref:
@@ -199,7 +199,7 @@ questions:
           description: The port for the Nextcloud Web UI.
           schema:
             type: int
-            default: 20810
+            default: 9001
             min: 9000
             max: 65535
             required: true

--- a/library/ix-dev/charts/nextcloud/templates/_configuration.tpl
+++ b/library/ix-dev/charts/nextcloud/templates/_configuration.tpl
@@ -80,6 +80,9 @@ secret:
         {{- $overwritehost := printf "%v:%v" .Values.ncConfig.host .Values.ncNetwork.webPort -}}
         {{- if .Values.ncNetwork.nginx.useDifferentAccessPort -}}
           {{ $overwritehost = printf "%v:%v" .Values.ncConfig.host .Values.ncNetwork.nginx.externalAccessPort -}}
+          {{- if contains ":" .Values.ncConfig.host -}}
+            {{- $overwritehost = .Values.ncConfig.host -}}
+          {{- end -}}
         {{- end }}
       OVERWRITEHOST: {{ $overwritehost }}
       {{- end }}

--- a/library/ix-dev/charts/nextcloud/templates/_configuration.tpl
+++ b/library/ix-dev/charts/nextcloud/templates/_configuration.tpl
@@ -63,7 +63,14 @@ secret:
       NEXTCLOUD_DATA_DIR: {{ .Values.ncConfig.dataDir }}
       PHP_UPLOAD_LIMIT: {{ printf "%vG" .Values.ncConfig.maxUploadLimit | default 3 }}
       PHP_MEMORY_LIMIT: {{ printf "%vM" .Values.ncConfig.phpMemoryLimit | default 512 }}
-      NEXTCLOUD_TRUSTED_DOMAINS: {{ list .Values.ncConfig.host "127.0.0.1" "localhost" $fullname (printf "%v-*" $fullname) | mustUniq | join " " | quote }}
+      {{- $host := "127.0.0.1" -}}
+      {{- if .Values.ncConfig.host -}}
+        {{- $host = printf "%v:%v" .Values.ncConfig.host .Values.ncNetwork.webPort -}}
+        {{- if contains ":" $host  -}} {{/* Make sure it always contains a port https://ixsystems.atlassian.net/browse/TNCHARTS-1016 */}}
+          {{- $host = .Values.ncConfig.host -}}
+        {{- end -}}
+      {{- end }}
+      NEXTCLOUD_TRUSTED_DOMAINS: {{ list $host "127.0.0.1" "localhost" (printf "%v-*" $fullname) $fullname | mustUniq | join " " | quote }}
       NEXTCLOUD_ADMIN_USER: {{ .Values.ncConfig.adminUser }}
       NEXTCLOUD_ADMIN_PASSWORD: {{ .Values.ncConfig.adminPassword }}
     {{- if .Values.ncNetwork.certificateID }}

--- a/library/ix-dev/charts/nextcloud/templates/_configuration.tpl
+++ b/library/ix-dev/charts/nextcloud/templates/_configuration.tpl
@@ -76,7 +76,7 @@ secret:
       APACHE_DISABLE_REWRITE_IP: "1"
       OVERWRITEPROTOCOL: "https"
       TRUSTED_PROXIES: {{ list $svcCidr $clusterCidr "127.0.0.1" | mustUniq | join " " | quote }}
-      {{- if and .Values.ncConfig.host .Values.ncNetwork.webPort }}
+      {{- if .Values.ncConfig.host }}
         {{- $overwritehost := .Values.ncConfig.host -}}
         {{- if .Values.ncNetwork.nginx.useDifferentAccessPort }}
           {{ $overwritehost = (printf "%v:%v" .Values.ncConfig.host .Values.ncNetwork.webPort) }}

--- a/library/ix-dev/charts/nextcloud/templates/_configuration.tpl
+++ b/library/ix-dev/charts/nextcloud/templates/_configuration.tpl
@@ -27,10 +27,10 @@
 
   {{/* Temporary set dynamic db details on values,
   so we can print them on the notes */}}
-  {{- $_ := set .Values "ncDbPass" $dbPass -}}
-  {{- $_ := set .Values "ncDbHost" $dbHost -}}
-  {{- $_ := set .Values "ncDbName" $dbName -}}
-  {{- $_ := set .Values "ncDbUser" $dbUser -}}
+  {{- $_ := set .Values "ncDbPass" $dbPass | quote -}}
+  {{- $_ := set .Values "ncDbHost" $dbHost | quote -}}
+  {{- $_ := set .Values "ncDbName" $dbName | quote -}}
+  {{- $_ := set .Values "ncDbUser" $dbUser | quote -}}
 
   {{- $dbURL := (printf "postgres://%s:%s@%s:5432/%s?sslmode=disable" $dbUser $dbPass $dbHost $dbName) }}
 secret:

--- a/library/ix-dev/charts/nextcloud/templates/_configuration.tpl
+++ b/library/ix-dev/charts/nextcloud/templates/_configuration.tpl
@@ -77,9 +77,9 @@ secret:
       OVERWRITEPROTOCOL: "https"
       TRUSTED_PROXIES: {{ list $svcCidr $clusterCidr "127.0.0.1" | mustUniq | join " " | quote }}
       {{- if .Values.ncConfig.host }}
-        {{- $overwritehost := .Values.ncConfig.host -}}
-        {{- if .Values.ncNetwork.nginx.useDifferentAccessPort }}
-          {{ $overwritehost = (printf "%v:%v" .Values.ncConfig.host .Values.ncNetwork.webPort) }}
+        {{- $overwritehost := printf "%v:%v" .Values.ncConfig.host .Values.ncNetwork.webPort -}}
+        {{- if .Values.ncNetwork.nginx.useDifferentAccessPort -}}
+          {{ $overwritehost = printf "%v:%v" .Values.ncConfig.host .Values.ncNetwork.nginx.externalAccessPort -}}
         {{- end }}
       OVERWRITEHOST: {{ $overwritehost }}
       {{- end }}

--- a/library/ix-dev/charts/nextcloud/templates/_configuration.tpl
+++ b/library/ix-dev/charts/nextcloud/templates/_configuration.tpl
@@ -75,7 +75,7 @@ secret:
       {{- end }}
       APACHE_DISABLE_REWRITE_IP: "1"
       OVERWRITEPROTOCOL: "https"
-      TRUSTED_PROXIES: {{ list  $svcCidr $clusterCidr "127.0.0.1" | mustUniq | join "," | quote }}
+      TRUSTED_PROXIES: {{ list $svcCidr $clusterCidr "127.0.0.1" | mustUniq | join " " | quote }}
       {{- if and .Values.ncConfig.host .Values.ncNetwork.webPort }}
         {{- $overwritehost := .Values.ncConfig.host -}}
         {{- if .Values.ncNetwork.nginx.useDifferentAccessPort }}

--- a/library/ix-dev/charts/nextcloud/templates/_nextcloud-configs.tpl
+++ b/library/ix-dev/charts/nextcloud/templates/_nextcloud-configs.tpl
@@ -12,4 +12,24 @@ configmap:
 
       limitrequestbody.conf: |
         LimitRequestBody {{ mul .Values.ncConfig.maxUploadLimit $bytesGB }}
+
+      occ: |
+        #!/bin/bash
+        uid="$(id -u)"
+        gid="$(id -g)"
+        if [ "$uid" = '0' ]; then
+          user='www-data'
+          group='www-data'
+        else
+          user="$uid"
+          group="$gid"
+        fi
+        run_as() {
+          if [ "$(id -u)" = 0 ]; then
+            su -p "$user" -s /bin/bash -c 'php /var/www/html/occ "$@"' - "$@"
+          else
+            /bin/bash -c 'php /var/www/html/occ "$@"' - "$@"
+          fi
+        }
+        run_as "$@"
 {{- end -}}

--- a/library/ix-dev/charts/nextcloud/templates/_nginx-configuration.tpl
+++ b/library/ix-dev/charts/nextcloud/templates/_nginx-configuration.tpl
@@ -36,8 +36,6 @@ configmap:
           }
 
           server {
-            server_name localhost;
-
             listen {{ .Values.ncNetwork.webPort }} ssl http2;
             listen [::]:{{ .Values.ncNetwork.webPort }} ssl http2;
 

--- a/library/ix-dev/charts/nextcloud/templates/_nginx-configuration.tpl
+++ b/library/ix-dev/charts/nextcloud/templates/_nginx-configuration.tpl
@@ -29,13 +29,6 @@ configmap:
         events {}
         http {
           server {
-            # redirects all http requests to https requests
-            listen 8000 default_server;
-            listen [::]:8000 default_server;
-            return 301 https://$host$request_uri;
-          }
-
-          server {
             listen {{ .Values.ncNetwork.webPort }} ssl http2;
             listen [::]:{{ .Values.ncNetwork.webPort }} ssl http2;
 

--- a/library/ix-dev/charts/nextcloud/templates/_nginx-configuration.tpl
+++ b/library/ix-dev/charts/nextcloud/templates/_nginx-configuration.tpl
@@ -10,7 +10,7 @@ scaleCertificate:
   {{ $timeout := 60 }}
   {{ $size := .Values.ncConfig.maxUploadLimit | default 3 }}
   {{ $useDiffAccessPort := false }}
-  {{ $externalAccessPort := "" }}
+  {{ $externalAccessPort := ":$server_port" }}
   {{/* Safely access key as it is conditionaly shown */}}
   {{ if hasKey .Values.ncNetwork "nginx" }}
     {{ $useDiffAccessPort = .Values.ncNetwork.nginx.useDifferentAccessPort }}
@@ -32,10 +32,12 @@ configmap:
             listen {{ .Values.ncNetwork.webPort }} ssl http2;
             listen [::]:{{ .Values.ncNetwork.webPort }} ssl http2;
 
+            # Redirect HTTP to HTTPS
+            error_page 497 https://$host{{ $externalAccessPort }}$request_uri;
+
             ssl_certificate '/etc/nginx-certs/public.crt';
             ssl_certificate_key '/etc/nginx-certs/private.key';
 
-            # maximum 3GB Upload File; change to fit your needs
             client_max_body_size {{ $size }}G;
 
             add_header Strict-Transport-Security "max-age=15552000; includeSubDomains; preload" always;
@@ -47,19 +49,11 @@ configmap:
             }
 
             location = /.well-known/carddav {
-              {{ if $useDiffAccessPort }}
               return 301 $scheme://$host{{ $externalAccessPort }}/remote.php/dav;
-              {{ else }}
-              return 301 $scheme://$host:$server_port/remote.php/dav;
-              {{ end }}
             }
 
             location = /.well-known/caldav {
-              {{ if $useDiffAccessPort }}
               return 301 $scheme://$host{{ $externalAccessPort }}/remote.php/dav;
-              {{ else }}
-              return 301 $scheme://$host:$server_port/remote.php/dav;
-              {{ end }}
             }
 
             location / {
@@ -76,11 +70,7 @@ configmap:
               proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
               proxy_set_header X-Forwarded-Proto https;
               proxy_set_header X-Forwarded-Host  $host;
-              {{ if $useDiffAccessPort }}
               proxy_set_header X-Forwarded-Port  {{ $externalAccessPort | default "443" | trimPrefix ":" }};
-              {{ else }}
-              proxy_set_header X-Forwarded-Port  $server_port;
-              {{ end }}
 
               # Proxy timeouts
               proxy_connect_timeout              {{ $timeout }}s;

--- a/library/ix-dev/charts/nextcloud/templates/_nginx-configuration.tpl
+++ b/library/ix-dev/charts/nextcloud/templates/_nginx-configuration.tpl
@@ -33,7 +33,7 @@ configmap:
             listen [::]:{{ .Values.ncNetwork.webPort }} ssl http2;
 
             # Redirect HTTP to HTTPS
-            error_page 497 https://$host{{ $externalAccessPort }}$request_uri;
+            error_page 497 301 =307 https://$host{{ $externalAccessPort }}$request_uri;
 
             ssl_certificate '/etc/nginx-certs/public.crt';
             ssl_certificate_key '/etc/nginx-certs/private.key';

--- a/library/ix-dev/charts/nextcloud/templates/_persistence.tpl
+++ b/library/ix-dev/charts/nextcloud/templates/_persistence.tpl
@@ -108,6 +108,16 @@ persistence:
           # https://github.com/nextcloud/docker/issues/1796
           mountPath: /etc/apache2/conf-enabled/limitrequestbody.conf
           subPath: limitrequestbody.conf
+  nc-occ:
+    enabled: true
+    type: configmap
+    objectName: nextcloud-config
+    defaultMode: "0755"
+    targetSelector:
+      nextcloud:
+        nextcloud:
+          mountPath: /usr/bin/occ
+          subPath: occ
   tmp:
     enabled: true
     type: emptyDir

--- a/library/ix-dev/charts/nextcloud/templates/_portal.tpl
+++ b/library/ix-dev/charts/nextcloud/templates/_portal.tpl
@@ -1,12 +1,24 @@
 {{- define "nextcloud.portal" -}}
+{{- $protocol := "http" -}}
+{{- if .Values.ncNetwork.certificateID -}}
+  {{- $protocol = "https" -}}
+{{- end -}}
+{{- $host := "$node_ip" -}}
+{{- if .Values.ncConfig.host -}}
+  {{- $host = .Values.ncConfig.host -}}
+{{- end -}}
+{{- $port := .Values.ncNetwork.webPort -}}
+{{- if .Values.ncNetwork.nginx.useDifferentAccessPort -}}
+  {{- $port = .Values.ncNetwork.nginx.externalAccessPort -}}
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: portal
 data:
-  port: {{ .Values.ncNetwork.webPort | quote }}
+  port: {{ $port | quote }}
   path: "/"
-  protocol: "http"
-  host: $node_ip
+  protocol: {{ $protocol }}
+  host: {{ $host | quote }}
 {{- end -}}

--- a/library/ix-dev/charts/nextcloud/values.yaml
+++ b/library/ix-dev/charts/nextcloud/values.yaml
@@ -87,3 +87,7 @@ notes:
     {{- $_ := unset .Values "ncDbName" }}
     {{- $_ := unset .Values "ncDbPass" }}
     {{- $_ := unset .Values "ncDbHost" }}
+
+    Note: Nextcloud will create an additional new user and password for the admin user
+    on first startup. You can find those credentials in the `/var/www/html/config/config.php` file
+    inside the container.


### PR DESCRIPTION
- Fixes #2444 / https://ixsystems.atlassian.net/browse/TNCHARTS-1017
- Various nginx simplifications
- Adds `occ` shortcut that picks up the correct user to run as automatically. (now instead of having to switch users etc, users can just do `occ --help`)
- Fixes OVERWRITEHOST variable when useExternalPort is enabled
- Fixes Portal button
- Fixes trusted-domains #2443 / https://ixsystems.atlassian.net/browse/TNCHARTS-1016

Notes:
Some installations that have already upgraded to v2.x.x and having issues should check the following:
- Make sure the `Pre v2 Storage Structure` is **checked**. This is located In Nextcloud App Edit screen, in Storage Section
- If you have a warning `Data directory is world readable` in the Overview page, In Nextcloud's webui. This is a false positive. (see #2243). To fix that, edit `/var/www/html/config/config.php` file go to the `trusted_domains`. Find the "ip address" of your server and **append** the port you access the application (by default 9001) eg `:9001`.
