### PR TITLE
nextcloud: fix db user encoding issue

### DIFF
--- a/library/ix-dev/charts/nextcloud/Chart.yaml
+++ b/library/ix-dev/charts/nextcloud/Chart.yaml
@@ -4,7 +4,7 @@ description: A file sharing server that puts the control and security of your ow
 annotations:
   title: Nextcloud
 type: application
-version: 2.0.5
+version: 2.0.6
 apiVersion: v2
 appVersion: 29.0.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/nextcloud/templates/_configuration.tpl
+++ b/library/ix-dev/charts/nextcloud/templates/_configuration.tpl
@@ -10,6 +10,9 @@
   {{/* Fetch secrets from pre-migration secret */}}
   {{- with (lookup "v1" "Secret" .Release.Namespace "db-details") -}}
     {{- $dbUser = ((index .data "db-user") | b64dec) -}}
+    {{- if contains "\\x" (printf "%q" $dbUser) -}}
+      {{- $dbUser = (index .data "db-user") -}}
+    {{- end -}}
     {{- $dbPass = ((index .data "db-password") | b64dec) -}}
   {{- end -}}
 


### PR DESCRIPTION
Due to some old bug with how secret was handled, in some cases the db-user was stored in a double encrypted way.
If it finds such thing, it fixes it now.