### PR TITLE
webdav: allow modifying the request body limit

### DIFF
--- a/library/ix-dev/community/webdav/Chart.yaml
+++ b/library/ix-dev/community/webdav/Chart.yaml
@@ -4,7 +4,7 @@ description: WebDAV is a set of extensions to the HTTP protocol which allows use
 annotations:
   title: WebDAV
 type: application
-version: 1.0.23
+version: 1.0.24
 apiVersion: v2
 appVersion: 2.4.59
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/webdav/ci/http-basicauth-values.yaml
+++ b/library/ix-dev/community/webdav/ci/http-basicauth-values.yaml
@@ -17,6 +17,7 @@ webdavStorage:
       description: My third disabled share
       hostPath: /mnt/{{.Release.Name }}/share3
       readOnly: true
+      maxRequestBodySizeInGB: 10
       fixPermissions: false
 
 webdavNetwork:

--- a/library/ix-dev/community/webdav/questions.yaml
+++ b/library/ix-dev/community/webdav/questions.yaml
@@ -180,8 +180,8 @@ questions:
                         Example: [share1] will be available at [http://<webdav-ip>:<webdav-port>/share1]
                       schema:
                         type: string
-                        valid_chars: '^[a-zA-Z0-9_-]+$'
-                        valid_chars_error: 'Share name can only consist of [Letters(a-z, A-Z), Numbers(0-9), Underscores(_), Dashes(-)]'
+                        valid_chars: "^[a-zA-Z0-9_-]+$"
+                        valid_chars_error: "Share name can only consist of [Letters(a-z, A-Z), Numbers(0-9), Underscores(_), Dashes(-)]"
                         required: true
                     - variable: description
                       label: Description
@@ -203,6 +203,14 @@ questions:
                       schema:
                         type: boolean
                         default: false
+                    - variable: maxRequestBodySizeInGB
+                      label: Max Request Body Size (in GB)
+                      description: |
+                        The maximum size of the request body in GB.
+                        If the request body size exceeds this value, the request will fail.
+                      schema:
+                        type: int
+                        default: 1
                     - variable: fixPermissions
                       label: Fix Permissions
                       description: |
@@ -245,7 +253,7 @@ questions:
                 schema:
                   type: string
                   max_length: 12
-                  valid_chars: '^[1-9][0-9]*([EPTGMK]i?|e[0-9]+)?$'
+                  valid_chars: "^[1-9][0-9]*([EPTGMK]i?|e[0-9]+)?$"
                   valid_chars_error: |
                     Valid Memory limit formats are</br>
                     - Suffixed with E/P/T/G/M/K - eg. 1G</br>

--- a/library/ix-dev/community/webdav/questions.yaml
+++ b/library/ix-dev/community/webdav/questions.yaml
@@ -208,6 +208,7 @@ questions:
                       description: |
                         The maximum size of the request body in GB.
                         If the request body size exceeds this value, the request will fail.
+                        Value of 0 means no limit.
                       schema:
                         type: int
                         default: 1
@@ -253,7 +254,7 @@ questions:
                 schema:
                   type: string
                   max_length: 12
-                  valid_chars: "^[1-9][0-9]*([EPTGMK]i?|e[0-9]+)?$"
+                  valid_chars: '^[1-9][0-9]*([EPTGMK]i?|e[0-9]+)?$'
                   valid_chars_error: |
                     Valid Memory limit formats are</br>
                     - Suffixed with E/P/T/G/M/K - eg. 1G</br>

--- a/library/ix-dev/community/webdav/templates/_helper.tpl
+++ b/library/ix-dev/community/webdav/templates/_helper.tpl
@@ -39,11 +39,13 @@ DavLockDB "/usr/local/apache2/var/DavLock"
   Options Indexes FollowSymLinks
 </Directory>
 {{- range .Values.webdavStorage.shares }}
+  {{ $bytesGB := 1073741824 }}
   {{- if .enabled }}
 # WebDav Share - {{ .name }}
 # Description: {{ .description }}
 Alias /{{ .name }} "/{{ include "webdav.shares.prefix" $ }}/{{ .name }}"
 <Directory "/{{ include "webdav.shares.prefix" $ }}/{{ .name }}">
+  LimitRequestBody {{ mul (.maxRequestBodySizeInGB | default 1) $bytesGB }}
 </Directory>
     {{- if .readOnly }}
 <Location "/{{ .name }}">


### PR DESCRIPTION
According to apache does the default LimitRequestBody is 1GB
https://httpd.apache.org/docs/2.4/mod/core.html#limitrequestbody

I've left the default as `1`, but now user can specify per share. 

Fixes #2478 
Fixes #2462