### PR TITLE
navidrome: allow passing in soundcard device

### DIFF
--- a/library/ix-dev/community/navidrome/Chart.yaml
+++ b/library/ix-dev/community/navidrome/Chart.yaml
@@ -3,7 +3,7 @@ description: Navidrome is a personal streaming service
 annotations:
   title: Navidrome
 type: application
-version: 1.2.9
+version: 1.2.10
 apiVersion: v2
 appVersion: 0.52.5
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/navidrome/questions.yaml
+++ b/library/ix-dev/community/navidrome/questions.yaml
@@ -33,6 +33,17 @@ questions:
           schema:
             type: string
             default: ""
+        - variable: localPlayback
+          label: Enable Local Playback
+          description: |
+            Enable local playback for Navidrome.</br>
+            This will allow you to play music from your local machine, by mounting</br>
+            the sound card to the container.</br>
+            Keep in mind that this will make the container to run with elevated privileges</br>
+            and privilege escalation. Use with caution.
+          schema:
+            type: boolean
+            default: false
         - variable: additionalEnvs
           label: Additional Environment Variables
           description: Configure additional environment variables for Navidrome.

--- a/library/ix-dev/community/navidrome/templates/_navidrome.tpl
+++ b/library/ix-dev/community/navidrome/templates/_navidrome.tpl
@@ -6,6 +6,11 @@ workload:
     type: Deployment
     podSpec:
       hostNetwork: {{ .Values.navidromeNetwork.hostNetwork }}
+      securityContext:
+        {{- if .Values.navidromeConfig.localPlayback }}
+        supplementalGroups:
+          - 29
+        {{- end }}
       containers:
         navidrome:
           enabled: true
@@ -15,6 +20,10 @@ workload:
             runAsUser: {{ .Values.navidromeRunAs.user }}
             runAsGroup: {{ .Values.navidromeRunAs.group }}
             readOnlyRootFilesystem: false
+            {{- if .Values.navidromeConfig.localPlayback }}
+            privileged: true
+            allowPrivilegeEscalation: true
+            {{- end }}
           env:
             ND_MUSICFOLDER: /music
             ND_DATAFOLDER: /data

--- a/library/ix-dev/community/navidrome/templates/_persistence.tpl
+++ b/library/ix-dev/community/navidrome/templates/_persistence.tpl
@@ -24,6 +24,16 @@ persistence:
         01-permissions:
           mountPath: /mnt/directories/music
         {{- end }}
+  {{- if .Values.navidromeConfig.localPlayback }}
+  snd-device:
+    enabled: true
+    type: hostPath
+    hostPath: /dev/snd
+    targetSelector:
+      navidrome:
+        navidrome:
+          mountPath: /dev/snd
+  {{- end }}
   {{- range $idx, $storage := .Values.navidromeStorage.additionalStorages }}
   {{ printf "navidrome-%v:" (int $idx) }}
     enabled: true

--- a/library/ix-dev/community/navidrome/values.yaml
+++ b/library/ix-dev/community/navidrome/values.yaml
@@ -9,7 +9,8 @@ resources:
     memory: 8Gi
 
 navidromeConfig:
-  uiWelcomeMessage: ''
+  uiWelcomeMessage: ""
+  localPlayback: false
   additionalEnvs: []
 
 navidromeNetwork:


### PR DESCRIPTION
Fixes #2379 
Sadly k8s api does not have an option to consume the "device" api of containers.
Which means in order to be able to use sound cards, privileged mode have to be enabled.

In this case it will only be enabled when the local playback is enabled.