### PR TITLE
npm: allow using 0 as uid/gid

### DIFF
--- a/library/ix-dev/community/nginx-proxy-manager/Chart.yaml
+++ b/library/ix-dev/community/nginx-proxy-manager/Chart.yaml
@@ -3,7 +3,7 @@ description: Expose your services easily and securely
 annotations:
   title: Nginx Proxy Manager
 type: application
-version: 1.0.30
+version: 1.0.31
 apiVersion: v2
 appVersion: 2.11.2
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/nginx-proxy-manager/questions.yaml
+++ b/library/ix-dev/community/nginx-proxy-manager/questions.yaml
@@ -70,7 +70,7 @@ questions:
           description: The user id that Nginx Proxy Manager files will be owned by.
           schema:
             type: int
-            min: 2
+            min: 0
             default: 568
             required: true
         - variable: group
@@ -78,7 +78,7 @@ questions:
           description: The group id that Nginx Proxy Manager files will be owned by.
           schema:
             type: int
-            min: 2
+            min: 0
             default: 568
             required: true
 


### PR DESCRIPTION
Fixes #2482 

Due to some heavy io operations (chown) at startup that are being executed at start up, users experience a lot of delay until app is up and running.
Or sometimes even failures due to probes timing out.

Allowing to run as root (which is what are the files owned by default, should skip or at least reduce the slow startup time.
I kept the default at 568, as I believe a user should explicitly set uid/gid to root, if desired.