### PR TITLE
Minecraft: Fixes for version 2024.5.0 of docker-minecraft-server

### DIFF
--- a/library/ix-dev/community/minecraft/Chart.yaml
+++ b/library/ix-dev/community/minecraft/Chart.yaml
@@ -3,7 +3,7 @@ description: Minecraft is a sandbox game
 annotations:
   title: Minecraft
 type: application
-version: 1.2.11
+version: 1.2.12
 apiVersion: v2
 appVersion: 2024.5.0
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/minecraft/questions.yaml
+++ b/library/ix-dev/community/minecraft/questions.yaml
@@ -95,44 +95,46 @@ questions:
                 description: Spigot
               - value: BUKKIT
                 description: Bukkit
-              - value: FORGE
-                description: Forge
-              - value: CATSERVER
-                description: CatServer
-              - value: CRUCIBLE
-                description: Crucible
-              - value: AUTO_CURSEFORGE
-                description: Auto CurseForge
-              - value: CUSTOM
-                description: Custom
-              - value: FABRIC
-                description: Fabric
-              - value: FTBA
-                description: Feed The Beast
-              - value: FORGE
-                description: Forge
-              - value: LOLISERVER
-                description: LoliServer
-              - value: LIMBO
-                description: Limbo
-              - value: MAGMA
-                description: Magma
-              - value: MODRINTH
-                description: Modrinth
-              - value: MOHIST
-                description: Mohist
-              - value: FABRIC
-                description: Fabric
               - value: PAPER
                 description: Paper
+              - value: FOLIA
+                description: Folia
+              - value: FABRIC
+                description: Fabric
+              - value: FORGE
+                description: Forge
+              - value: NEOFORGE
+                description: NeoForge
+              - value: AUTO_CURSEFORGE
+                description: CurseForge
+              - value: MODRINTH
+                description: Modrinth
+              - value: FTBA
+                description: Feed the Beast
               - value: PUFFERFISH
                 description: Pufferfish
               - value: PURPUR
                 description: Purpur
               - value: QUILT
                 description: Quilt
+              - value: MAGMA
+                description: Magma
+              - value: MAGMA_MAINTAINED
+                description: Magma Maintained
+              - value: KETTING
+                description: Ketting
+              - value: MOHIST
+                description: Mohist
+              - value: CATSERVER
+                description: Catserver
               - value: SPONGEVANILLA
                 description: SpongeVanilla
+              - value: LIMBO
+                description: Limbo
+              - value: CRUCIBLE
+                description: Crucible
+              - value: CUSTOM
+                description: Custom
         - variable: version
           label: Version
           description: |

--- a/library/ix-dev/community/minecraft/questions.yaml
+++ b/library/ix-dev/community/minecraft/questions.yaml
@@ -42,7 +42,7 @@ questions:
             need to adjust the Version and Type fields.
           schema:
             type: string
-            default: "j17Image"
+            default: "j21Image"
             required: true
             enum:
               - value: j8Image

--- a/library/ix-dev/community/minecraft/templates/_configuration.tpl
+++ b/library/ix-dev/community/minecraft/templates/_configuration.tpl
@@ -56,10 +56,11 @@ configmap:
     {{- fail "Minecraft - You have to accept EULA" -}}
   {{- end -}}
 
-  {{- $types := (list "VANILLA" "SPIGOT" "BUKKIT" "CATSERVER" "CRUCIBLE"
-                      "AUTO_CURSEFORGE" "CUSTOM" "FABRIC" "FTBA" "FORGE"
-                      "LOLISERVER" "LIMBO" "MAGMA" "MODRINTH" "MOHIST"
-                      "FABRIC" "PAPER" "PUFFERFISH" "PURPUR" "QUILT") -}}
+  {{- $types := (list "VANILLA" "SPIGOT" "BUKKIT" "PAPER" "FOLIA"
+                      "FABRIC" "FORGE" "NEOFORGE" "AUTO_CURSEFORGE" "MODRINTH"
+                      "FTBA" "PUFFERFISH" "PURPUR" "QUILT" "MAGMA"
+                      "MAGMA_MAINTAINED" "KETTING" "MOHIST" "CATSERVER" "SPONGEVANILLA"
+                      "LIMBO" "CRUCIBLE" "CUSTOM") -}}
   {{- if not (mustHas .Values.mcConfig.type $types) -}}
     {{- fail (printf "Minecraft - Expected [Type] to be one of [%s], but got [%s]" (join ", " $types) .Values.mcConfig.type) -}}
   {{- end -}}

--- a/library/ix-dev/community/minecraft/values.yaml
+++ b/library/ix-dev/community/minecraft/values.yaml
@@ -70,7 +70,7 @@ resources:
 
 mcConfig:
   eula: false
-  imageSelector: j17Image
+  imageSelector: j21Image
   version: LATEST
   type: VANILLA
   serverName: Minecraft Server


### PR DESCRIPTION
I made the following changes:

- Changed the default java version to 21, as the docker image this app is based on also changed heir default version to 21.
- Updated the list of supported server types, based on what version 2024.5.0 supports.
- Bumped the version of the chart app