### PR TITLE
home-assistant: allow enabling privileged mode for devices

### DIFF
--- a/library/ix-dev/charts/home-assistant/Chart.yaml
+++ b/library/ix-dev/charts/home-assistant/Chart.yaml
@@ -4,7 +4,7 @@ description: Home Assistant is an open source home automation that puts local co
 annotations:
   title: Home Assistant
 type: application
-version: 2.0.25
+version: 2.0.26
 apiVersion: v2
 appVersion: 2024.5.5
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/charts/home-assistant/ci/devices-values.yaml
+++ b/library/ix-dev/charts/home-assistant/ci/devices-values.yaml
@@ -1,0 +1,18 @@
+haConfig:
+  allowDevices: true
+
+haNetwork:
+  webPort: 31000
+
+haStorage:
+  config:
+    type: pvc
+  media:
+    type: pvc
+  pgData:
+    type: pvc
+  pgBackup:
+    type: emptyDir
+    emptyDirConfig:
+      medium: ""
+      size: ""

--- a/library/ix-dev/charts/home-assistant/questions.yaml
+++ b/library/ix-dev/charts/home-assistant/questions.yaml
@@ -33,6 +33,38 @@ questions:
       $ref:
         - definitions/timezone
 
+  - variable: haConfig
+    label: ""
+    group: Home Assistant Configuration
+    schema:
+      type: dict
+      attrs:
+        - variable: allowDevices
+          label: Allow Devices
+          description: |
+            Allow devices to be added to Home Assistant.
+            Keep in mind that this will make the container to run with elevated privileges.</br>
+            Use with caution.
+          schema:
+            type: boolean
+            default: false
+        - variable: additionalEnvs
+          label: Additional Environment Variables
+          description: Additional environment variables for Home Assistant.
+          schema:
+            type: list
+            items:
+              - variable: name
+                label: Name
+                schema:
+                  type: string
+                  required: true
+              - variable: value
+                label: Value
+                schema:
+                  type: string
+                  required: true
+
   - variable: podOptions
     label: ""
     group: Advanced Pod Configuration
@@ -109,7 +141,6 @@ questions:
             min: 568
             default: 568
             required: true
-
 
   - variable: haStorage
     label: ""
@@ -623,7 +654,7 @@ questions:
                 schema:
                   type: string
                   max_length: 12
-                  valid_chars: '^[1-9][0-9]*([EPTGMK]i?|e[0-9]+)?$'
+                  valid_chars: "^[1-9][0-9]*([EPTGMK]i?|e[0-9]+)?$"
                   valid_chars_error: |
                     Valid Memory limit formats are</br>
                     - Suffixed with E/P/T/G/M/K - eg. 1G</br>

--- a/library/ix-dev/charts/home-assistant/questions.yaml
+++ b/library/ix-dev/charts/home-assistant/questions.yaml
@@ -654,7 +654,7 @@ questions:
                 schema:
                   type: string
                   max_length: 12
-                  valid_chars: "^[1-9][0-9]*([EPTGMK]i?|e[0-9]+)?$"
+                  valid_chars: '^[1-9][0-9]*([EPTGMK]i?|e[0-9]+)?$'
                   valid_chars_error: |
                     Valid Memory limit formats are</br>
                     - Suffixed with E/P/T/G/M/K - eg. 1G</br>

--- a/library/ix-dev/charts/home-assistant/questions.yaml
+++ b/library/ix-dev/charts/home-assistant/questions.yaml
@@ -43,8 +43,8 @@ questions:
           label: Allow Devices
           description: |
             Allow devices to be added to Home Assistant.
-            Keep in mind that this will make the container to run with elevated privileges.</br>
-            Use with caution.
+            Keep in mind that this will make the container to run with elevated privileges</br>
+            and privilege escalation. Use with caution.
           schema:
             type: boolean
             default: false

--- a/library/ix-dev/charts/home-assistant/templates/_home-assistant.tpl
+++ b/library/ix-dev/charts/home-assistant/templates/_home-assistant.tpl
@@ -17,6 +17,7 @@ workload:
             runAsUser: 0
             runAsGroup: 0
             runAsNonRoot: false
+            privileged: {{ .Values.haConfig.allowDevices | default false }}
             readOnlyRootFilesystem: false
             capabilities:
               add:

--- a/library/ix-dev/charts/home-assistant/templates/_home-assistant.tpl
+++ b/library/ix-dev/charts/home-assistant/templates/_home-assistant.tpl
@@ -18,6 +18,7 @@ workload:
             runAsGroup: 0
             runAsNonRoot: false
             privileged: {{ .Values.haConfig.allowDevices | default false }}
+            allowPrivilegeEscalation: {{ .Values.haConfig.allowDevices | default false }}
             readOnlyRootFilesystem: false
             capabilities:
               add:

--- a/library/ix-dev/charts/home-assistant/values.yaml
+++ b/library/ix-dev/charts/home-assistant/values.yaml
@@ -8,7 +8,7 @@ image:
 haPostgresImage:
   pullPolicy: IfNotPresent
   repository: postgres
-  tag: "13.1"
+  tag: '13.1'
 
 yqImage:
   pullPolicy: IfNotPresent
@@ -25,7 +25,7 @@ podOptions:
     options: []
 
 haConfig:
-  allowDevices: true
+  allowDevices: false
   additionalEnvs: []
 
 haNetwork:

--- a/library/ix-dev/charts/home-assistant/values.yaml
+++ b/library/ix-dev/charts/home-assistant/values.yaml
@@ -8,7 +8,7 @@ image:
 haPostgresImage:
   pullPolicy: IfNotPresent
   repository: postgres
-  tag: '13.1'
+  tag: "13.1"
 
 yqImage:
   pullPolicy: IfNotPresent
@@ -25,6 +25,7 @@ podOptions:
     options: []
 
 haConfig:
+  allowDevices: true
   additionalEnvs: []
 
 haNetwork:


### PR DESCRIPTION
Fixes #1478

Allows privileged flag to be set, this allows devices to be mounted/used.
Appropriate warning is also added in the description of the toggle.