### PR TITLE
tautulli: switch to upstream image

### DIFF
--- a/library/ix-dev/community/tautulli/Chart.yaml
+++ b/library/ix-dev/community/tautulli/Chart.yaml
@@ -3,9 +3,9 @@ description: Tautulli is a python based web application for monitoring, analytic
 annotations:
   title: Tautulli
 type: application
-version: 1.2.3
+version: 1.2.4
 apiVersion: v2
-appVersion: 2.13.4
+appVersion: v2.14.2
 kubeVersion: '>=1.16.0-0'
 maintainers:
   - name: truenas

--- a/library/ix-dev/community/tautulli/templates/_tautulli.tpl
+++ b/library/ix-dev/community/tautulli/templates/_tautulli.tpl
@@ -14,11 +14,17 @@ workload:
           securityContext:
             runAsUser: {{ .Values.tautulliRunAs.user }}
             runAsGroup: {{ .Values.tautulliRunAs.group }}
+          entrypoint:
           command:
-            - /entrypoint.sh
+            - python
+            - Tautulli.py
           args:
             - --port
             - {{ .Values.tautulliNetwork.webPort | quote }}
+            - --config
+            - /config/config.ini
+            - --datadir
+            - /config
           {{ with .Values.tautulliConfig.additionalEnvs }}
           envList:
             {{ range $env := . }}

--- a/library/ix-dev/community/tautulli/templates/_tautulli.tpl
+++ b/library/ix-dev/community/tautulli/templates/_tautulli.tpl
@@ -14,7 +14,6 @@ workload:
           securityContext:
             runAsUser: {{ .Values.tautulliRunAs.user }}
             runAsGroup: {{ .Values.tautulliRunAs.group }}
-          entrypoint:
           command:
             - python
             - Tautulli.py

--- a/library/ix-dev/community/tautulli/upgrade_strategy
+++ b/library/ix-dev/community/tautulli/upgrade_strategy
@@ -6,12 +6,12 @@ import sys
 from catalog_update.upgrade_strategy import semantic_versioning
 
 
-RE_STABLE_VERSION = re.compile(r'[0-9]+\.[0-9]+\.[0-9]+')
+RE_STABLE_VERSION = re.compile(r'v[0-9]+\.[0-9]+\.[0-9]+')
 
 
 def newer_mapping(image_tags):
     key = list(image_tags.keys())[0]
-    tags = {t: t for t in image_tags[key] if RE_STABLE_VERSION.fullmatch(t)}
+    tags = {t.strip('v'): t for t in image_tags[key]}
     version = semantic_versioning(list(tags))
     if not version:
         return {}

--- a/library/ix-dev/community/tautulli/values.yaml
+++ b/library/ix-dev/community/tautulli/values.yaml
@@ -1,7 +1,7 @@
 image:
-  repository: ghcr.io/onedr0p/tautulli
+  repository: tautulli/tautulli
   pullPolicy: IfNotPresent
-  tag: 2.13.4
+  tag: v2.14.2
 
 resources:
   limits:


### PR DESCRIPTION
Upstream maintainer deprecated the image, switching to the official.
https://github.com/Tautulli/Tautulli/pull/2301#issuecomment-2054107140