### PR TITLE
add config option for jellyfin timezone

### DIFF
--- a/community/jellyfin/1.2.16/questions.yaml
+++ b/community/jellyfin/1.2.16/questions.yaml
@@ -21,6 +21,16 @@ portals:
     path: "$kubernetes-resource_configmap_portal_path"
 
 questions:
+  - variable: TZ
+    group: Jellyfin Configuration
+    label: Timezone
+    schema:
+      type: string
+      default: Etc/UTC
+      required: true
+      $ref:
+        - definitions/timezone
+
   - variable: jellyfinConfig
     label: ""
     group: Jellyfin Configuration

--- a/community/jellyfin/1.2.16/questions.yaml
+++ b/community/jellyfin/1.2.16/questions.yaml
@@ -21,16 +21,6 @@ portals:
     path: "$kubernetes-resource_configmap_portal_path"
 
 questions:
-  - variable: TZ
-    group: Jellyfin Configuration
-    label: Timezone
-    schema:
-      type: string
-      default: Etc/UTC
-      required: true
-      $ref:
-        - definitions/timezone
-
   - variable: jellyfinConfig
     label: ""
     group: Jellyfin Configuration

--- a/library/ix-dev/community/jellyfin/Chart.yaml
+++ b/library/ix-dev/community/jellyfin/Chart.yaml
@@ -4,7 +4,7 @@ description: Jellyfin is a Free Software Media System that puts you in control o
 annotations:
   title: Jellyfin
 type: application
-version: 1.2.16
+version: 1.3.0
 apiVersion: v2
 appVersion: 10.9.6
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/jellyfin/questions.yaml
+++ b/library/ix-dev/community/jellyfin/questions.yaml
@@ -21,6 +21,16 @@ portals:
     path: "$kubernetes-resource_configmap_portal_path"
 
 questions:
+  - variable: TZ
+    group: Jellyfin Configuration
+    label: Timezone
+    schema:
+      type: string
+      default: Etc/UTC
+      required: true
+      $ref:
+        - definitions/timezone
+
   - variable: jellyfinConfig
     label: ""
     group: Jellyfin Configuration


### PR DESCRIPTION
Attempts to maybe possibly fix #2574. untested! copies timezone question blocks I saw in other community charts.