### PR TITLE
tdarr: fix upgrade regex

### DIFF
--- a/library/ix-dev/community/tdarr/Chart.yaml
+++ b/library/ix-dev/community/tdarr/Chart.yaml
@@ -3,9 +3,9 @@ description: Tdarr is a Distributed Transcoding System
 annotations:
   title: Tdarr
 type: application
-version: 1.2.3
+version: 1.2.4
 apiVersion: v2
-appVersion: '2.17.01'
+appVersion: 2.17.01
 kubeVersion: '>=1.16.0-0'
 maintainers:
   - name: truenas

--- a/library/ix-dev/community/tdarr/upgrade_strategy
+++ b/library/ix-dev/community/tdarr/upgrade_strategy
@@ -7,7 +7,7 @@ from catalog_update.upgrade_strategy import semantic_versioning
 
 
 # Drop _ffmpeg5 after Cobia is released for a while
-RE_STABLE_VERSION = re.compile(r'[0-9]+\.[0-9]+\.[0-9]+_ffmpeg5')
+RE_STABLE_VERSION = re.compile(r'[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?(_ffmpeg5)?')
 STRIP_TEXT = '_ffmpeg5'
 
 

--- a/library/ix-dev/community/tdarr/values.yaml
+++ b/library/ix-dev/community/tdarr/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: haveagitgat/tdarr
   pullPolicy: IfNotPresent
-  tag: '2.17.01'
+  tag: 2.17.01
 
 resources:
   limits:


### PR DESCRIPTION
Noticed this morning that Tdarr has not upgraded for several versions.  I believe it's due to the regex having `_ffmpeg5` as a required suffix.  Tdarr has suffixed `_ffmpeg5` on some image tags but not the most recent, and sometimes used 4 version segments according to the tag history on DockerHub; https://hub.docker.com/r/haveagitgat/tdarr/tags.

Updated the regex in the upgrade_strategy to support both scenarios.  Also removed the string quotes on the tag - likely not the issue but consistent with other applications.

Please let me know if you would like an Issue ticket for this as well.  Thank you very much!