### PR TITLE
tdarr: handle version numbers with leading zeros (e.g. 2.21.01)

### DIFF
--- a/library/ix-dev/community/tdarr/Chart.yaml
+++ b/library/ix-dev/community/tdarr/Chart.yaml
@@ -3,7 +3,7 @@ description: Tdarr is a Distributed Transcoding System
 annotations:
   title: Tdarr
 type: application
-version: 1.2.4
+version: 1.2.5
 apiVersion: v2
 appVersion: 2.17.01
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/tdarr/upgrade_strategy
+++ b/library/ix-dev/community/tdarr/upgrade_strategy
@@ -8,12 +8,13 @@ from catalog_update.upgrade_strategy import semantic_versioning
 
 # Drop _ffmpeg5 after Cobia is released for a while
 RE_STABLE_VERSION = re.compile(r'[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?(_ffmpeg5)?')
+RE_CLEAN_VERSION = re.compile(r'0+([1-9])')
 STRIP_TEXT = '_ffmpeg5'
 
 
 def newer_mapping(image_tags):
     key = list(image_tags.keys())[0]
-    tags = {t.strip(STRIP_TEXT): t for t in image_tags[key] if RE_STABLE_VERSION.fullmatch(t)}
+    tags = {RE_CLEAN_VERSION.sub("\\1", t.strip(STRIP_TEXT)): t for t in image_tags[key] if RE_STABLE_VERSION.fullmatch(t)}
     version = semantic_versioning(list(tags))
     if not version:
         return {}


### PR DESCRIPTION
This is a followup PR to https://github.com/truenas/charts/pull/2583 that I missed the python script needs to handle version numbers with leading zeros in the digit groups (e.g 2.21.01) with how the upgrade_strategy semantic_versioning works.

Using compiled regex to strip leading zeros in front of other digits.

I really don't know python well so please let me know if there's a better way to do this.  Thank you for the review and sorry about the extra PR!