### PR TITLE
ci: change k3s version

### DIFF
--- a/.github/workflows/charts_tests.yaml
+++ b/.github/workflows/charts_tests.yaml
@@ -90,7 +90,7 @@ jobs:
           - v3.12.1
         # We run tests on k3s version of latest SCALE release
         k3s-version:
-          - v1.26.6+k3s1
+          - v1.26.15+k3s1
 
     steps:
       - name: Checkout

--- a/.github/workflows/common_library_tests.yaml
+++ b/.github/workflows/common_library_tests.yaml
@@ -94,7 +94,7 @@ jobs:
       matrix:
         # We run tests on k3s version of latest SCALE release, SCALE nightly and manually defined "latest"
         k3s-version:
-          - v1.26.6+k3s1
+          - v1.26.15+k3s1
         # We run tests on Helm version of latest SCALE release, SCALE nightly and manually defined "latest"
         helm-version:
           - v3.12.1


### PR DESCRIPTION
The action we use for setting up k3s is only fetching versions in the first 2 pages of the github api.
So the version we had defined is out of that range now.

I've updated the patch version within the same minor version range.
This version is listed in the "available versions" list.
See failures in here #2666 