### PR TITLE
tdarr: fix versions containing `5`

### DIFF
--- a/library/ix-dev/community/tdarr/Chart.yaml
+++ b/library/ix-dev/community/tdarr/Chart.yaml
@@ -3,7 +3,7 @@ description: Tdarr is a Distributed Transcoding System
 annotations:
   title: Tdarr
 type: application
-version: 1.2.11
+version: 1.2.12
 apiVersion: v2
 appVersion: 2.24.4
 kubeVersion: '>=1.16.0-0'

--- a/library/ix-dev/community/tdarr/upgrade_strategy
+++ b/library/ix-dev/community/tdarr/upgrade_strategy
@@ -7,15 +7,14 @@ from catalog_update.upgrade_strategy import semantic_versioning
 
 
 # Drop _ffmpeg5 after Cobia is released for a while
-RE_STABLE_VERSION = re.compile(r'[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?(_ffmpeg5)?')
+RE_STABLE_VERSION = re.compile(r'[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?')
 RE_CLEAN_VERSION = re.compile(r'0+([1-9])')
-STRIP_TEXT = '_ffmpeg5'
 
 
 def newer_mapping(image_tags):
     key = list(image_tags.keys())[0]
     tags = {
-        RE_CLEAN_VERSION.sub('\\1', t.strip(STRIP_TEXT)): t
+        RE_CLEAN_VERSION.sub('\\1', t): t
         for t in image_tags[key]
         if RE_STABLE_VERSION.fullmatch(t)
     }


### PR DESCRIPTION
This is yet another followup to https://github.com/truenas/charts/pull/2604.  Not knowing python I left in the `.strip(STRIP_TEXT)` thinking it operated like a string replace while in fact it's more like a regex removal.  This prevents any version with a `5` in it from being accepted.  Tdarr has not used the _ffmpeg5 suffix in about a year so just removing it from the upgrade_strategy to fix.

Before:
```
root@d34bab76ac83:/app# cat test.json | python3 upgrade_strategy
{'1.13.1': '1.13.01', '2.13.1': '2.13.01_ffmpeg5', '2.18.1': '2.18.01', '2.18.2': '2.18.02', '2.19.1': '2.19.01', '2.20.1': '2.20.01', '2.21.1': '2.21.01', '2.22.1': '2.22.01', '2.23.1': '2.23.01', '2.24.1': '2.24.01', '2.24.2': '2.24.02', '2.24.3': '2.24.03', '2.24.4': '2.24.04', '2.24.0': '2.24.05'}
{"tags": {"image": "2.24.04"}, "app_version": "2.24.4"}
```
After:
```
root@d34bab76ac83:/app# cat test.json | python3 upgrade_strategy
{'1.13.1': '1.13.01', '2.18.1': '2.18.01', '2.18.2': '2.18.02', '2.19.1': '2.19.01', '2.20.1': '2.20.01', '2.21.1': '2.21.01', '2.22.1': '2.22.01', '2.23.1': '2.23.01', '2.24.1': '2.24.01', '2.24.2': '2.24.02', '2.24.3': '2.24.03', '2.24.4': '2.24.04', '2.24.5': '2.24.05'}
{"tags": {"image": "2.24.05"}, "app_version": "2.24.5"}
```

Thank you again for yet another review and being a n00b 😶