### PR TITLE
update omada-controller

### DIFF
--- a/library/ix-dev/community/omada-controller/Chart.yaml
+++ b/library/ix-dev/community/omada-controller/Chart.yaml
@@ -4,9 +4,9 @@ description: Omada Controller (TP-Link) is a network management controller for T
 annotations:
   title: Omada Controller
 type: application
-version: 1.2.4
+version: 1.2.5
 apiVersion: v2
-appVersion: '5.14'
+appVersion: '5.14.30.7'
 kubeVersion: '>=1.16.0-0'
 maintainers:
   - name: truenas

--- a/library/ix-dev/community/omada-controller/upgrade_strategy
+++ b/library/ix-dev/community/omada-controller/upgrade_strategy
@@ -6,7 +6,7 @@ import sys
 from catalog_update.upgrade_strategy import semantic_versioning
 
 
-RE_STABLE_VERSION = re.compile(r'\d+\.\d+')
+RE_STABLE_VERSION = re.compile(r'\d+\.\d+\.\d+\.\d+')
 
 
 def newer_mapping(image_tags):

--- a/library/ix-dev/community/omada-controller/values.yaml
+++ b/library/ix-dev/community/omada-controller/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: mbentley/omada-controller
   pullPolicy: IfNotPresent
-  tag: '5.14'
+  tag: "beta-5.14.30.7"
 
 resources:
   limits:


### PR DESCRIPTION
Updates omada-controller to a working tag.

https://github.com/mbentley/docker-omada-controller/issues/418#issuecomment-2294841199

It seems that 5.14 was always beta, but wasn't marked as such initially.
Now that is marked as beta, I'm pinning it at a known working version, until a new stable version releases.
Updated upgrade strategy regex to match stable versions, so we should get a PR when one is out.