### PR TITLE
frigate: Increase max cache size 

### DIFF
--- a/community/frigate/1.2.8/questions.yaml
+++ b/community/frigate/1.2.8/questions.yaml
@@ -325,7 +325,7 @@ questions:
                 description: The size of RAM is allowed to Frigate to use as cache
                 schema:
                   type: int
-                  max: 4
+                  max: 8
                   default: 1
                   required: true
         - variable: shm


### PR DESCRIPTION
Facing cache issues, therefore it would be useful to be able to increase this past 4GB