### PR TITLE
Remove Limit for Gitea External SSH

### DIFF
--- a/community/gitea/app_versions.json
+++ b/community/gitea/app_versions.json
@@ -222,7 +222,7 @@
                                     "type": "int",
                                     "null": true,
                                     "default": null,
-                                    "min": 9000,
+                                    "min": 22,
                                     "max": 65535
                                 }
                             },


### PR DESCRIPTION
I believe that there shouldn't be a limit on this as the user will usually port forward this. It makes it easier to be able to access the Gitea server as well.