### PR TITLE
Frigate: Add new authenticated UI / API port to app

### DIFF
--- a/community/frigate/1.2.8/ci/basic-values.yaml
+++ b/community/frigate/1.2.8/ci/basic-values.yaml
@@ -6,6 +6,8 @@ frigateNetwork:
   rtspPort: 31002
   enableWebRtc: true
   webRtcPort: 31003
+  enableAuthenticatedUI: true
+  authenticatedUIPort: 31004
 
 frigateStorage:
   config:

--- a/community/frigate/1.2.8/ci/extra-values.yaml
+++ b/community/frigate/1.2.8/ci/extra-values.yaml
@@ -6,6 +6,8 @@ frigateNetwork:
   rtspPort: 31002
   enableWebRtc: true
   webRtcPort: 31003
+  enableAuthenticatedUI: true
+  authenticatedUIPort: 31004
 
 frigateConfig:
   mountUSBBus: true

--- a/community/frigate/1.2.8/ci/hostNet-values.yaml
+++ b/community/frigate/1.2.8/ci/hostNet-values.yaml
@@ -2,6 +2,7 @@ frigateNetwork:
   enableRtmp: true
   enableRtsp: true
   enableWebRtc: true
+  enableAuthenticatedUI: true
   hostNetwork: true
 
 frigateStorage:

--- a/community/frigate/1.2.8/ix_values.yaml
+++ b/community/frigate/1.2.8/ix_values.yaml
@@ -28,6 +28,8 @@ frigateNetwork:
   rtspPort: 30060
   enableWebRtc: false
   webRtcPort: 30061
+  enableAuthenticatedUI: false
+  authenticatedUIPort: 30062
 
 frigateGPU: {}
 

--- a/community/frigate/1.2.8/questions.yaml
+++ b/community/frigate/1.2.8/questions.yaml
@@ -101,7 +101,7 @@ questions:
                 schema:
                   type: boolean
                   default: false
-              - variable: rtmpPort
+              - variable: authenticatedUIPort
                 label: Authenticated Web UI Port
                 description: |
                   The port for the Frigate Web UI with authentication.</br>

--- a/community/frigate/1.2.8/questions.yaml
+++ b/community/frigate/1.2.8/questions.yaml
@@ -95,6 +95,17 @@ questions:
                   min: 9000
                   max: 65535
                   required: true
+              - variable: authenticatedWeb
+                label: Authenticated Web-Port
+                description: |
+                  The port for the Frigate Web UI with authentication.</br>
+                  Internal port: 8971
+                schema:
+                  type: int
+                  default: 30062
+                  min: 9000
+                  max: 65535
+                  required: true
               - variable: enableRtmp
                 label: Enable RTMP
                 description: Enable RTMP for Frigate.

--- a/community/frigate/1.2.8/questions.yaml
+++ b/community/frigate/1.2.8/questions.yaml
@@ -95,14 +95,21 @@ questions:
                   min: 9000
                   max: 65535
                   required: true
-              - variable: authenticatedWeb
-                label: Authenticated Web-Port
+              - variable: enableAuthenticatedUI
+                label: Enable Authenticated UI
+                description: Enable Authenticated UI for Frigate.
+                schema:
+                  type: boolean
+                  default: false
+              - variable: rtmpPort
+                label: Authenticated Web UI Port
                 description: |
                   The port for the Frigate Web UI with authentication.</br>
                   Internal port: 8971
                 schema:
                   type: int
                   default: 30062
+                  show_if: [["enableAuthenticatedUI", "=", true]]
                   min: 9000
                   max: 65535
                   required: true

--- a/community/frigate/1.2.8/templates/_service.tpl
+++ b/community/frigate/1.2.8/templates/_service.tpl
@@ -13,6 +13,20 @@ service:
         nodePort: {{ .Values.frigateNetwork.webPort }}
         targetPort: 5000
         targetSelector: frigate
+  {{ if .Values.frigateNetwork.enableAuthenticatedUI }}
+  authUI:
+    enabled: true
+    type: NodePort
+    targetSelector: frigate
+    ports:
+      authUI:
+        enabled: true
+        primary: true
+        port: {{ .Values.frigateNetwork.authenticatedUIPort }}
+        nodePort: {{ .Values.frigateNetwork.authenticatedUIPort }}
+        targetPort: 8971
+        targetSelector: frigate
+  {{ end }}
   {{ if .Values.frigateNetwork.enableRtmp }}
   rtmp:
     enabled: true

--- a/community/frigate/app_versions.json
+++ b/community/frigate/app_versions.json
@@ -302,6 +302,34 @@
                                                 "max": 65535,
                                                 "required": true
                                             }
+                                        },
+                                        {
+                                            "variable": "enableAuthenticatedUI",
+                                            "label": "Enable authenticated UI",
+                                            "description": "Enable the authenticated web ui for frigate",
+                                            "schema": {
+                                                "type": "boolean",
+                                                "default": false
+                                            }
+                                        },
+                                        {
+                                            "variable": "authenticatedUIPort",
+                                            "label": "Authenticated UI Port",
+                                            "description": "The authenticated UI port for Frigate.</br>\nInternal port: 8971</br>\n",
+                                            "schema": {
+                                                "type": "int",
+                                                "default": 30062,
+                                                "show_if": [
+                                                    [
+                                                        "enableAuthenticatedUI",
+                                                        "=",
+                                                        true
+                                                    ]
+                                                ],
+                                                "min": 9000,
+                                                "max": 65535,
+                                                "required": true
+                                            }
                                         }
                                     ]
                                 }


### PR DESCRIPTION
I have been setting up Frigate and noticed that the TrueNAS Scale app didn't yet have the authenticated UI port forwarded, so I went on to add that. It probably isn't correct just yet, just tell me what is incorrect or fix it yourself. Thanks for y'all's great work!