### PR TITLE
Change default guid and uid from 568 to 1000 in N8N

### DIFF
--- a/community/n8n/1.2.115/questions.yaml
+++ b/community/n8n/1.2.115/questions.yaml
@@ -76,7 +76,7 @@ questions:
           schema:
             type: int
             min: 2
-            default: 568
+            default: 1000
             required: true
         - variable: group
           label: Group ID
@@ -84,7 +84,7 @@ questions:
           schema:
             type: int
             min: 2
-            default: 568
+            default: 1000
             required: true
 
   - variable: n8nNetwork


### PR DESCRIPTION
Updated the default guid and uid values from 568 to 1000 to avoid permission issues when installing community nodes. 

https://community.n8n.io/t/unable-to-install-any-community-nodes-on-n8n-truenas-scale-24-10-2/90807/4